### PR TITLE
feat: added public lib docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,74 @@
+name: Docs
+
+# Build the VitePress site and deploy it to GitHub Pages.
+#
+# One-time setup: in the repository Settings → Pages, set
+# "Build and deployment" → Source to "GitHub Actions".
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+      - "packages/*/README.md"
+      - ".github/workflows/docs.yml"
+  # Allow manual runs from the Actions tab.
+  workflow_dispatch:
+
+# Allow the GITHUB_TOKEN to deploy to Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress run so a
+# published deploy always finishes.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # for lastUpdated git timestamps
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Twoslash type-checks the code samples against the built packages, so
+      # the workspaces must be built before the docs.
+      - name: Build packages
+        run: npm run build
+
+      - name: Build docs
+        run: npm run docs:build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ dist/
 .svelte-kit/
 *.tsbuildinfo
 
+# VitePress
+docs/.vitepress/cache/
+docs/.vitepress/dist/
+
 # Test artifacts
 coverage/
 playwright-report/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,30 @@
-# isorouter
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="public/logo.svg">
+    <img src="public/logo-light.svg" alt="isorouter logo" width="120" height="120">
+  </picture>
+</p>
+
+<h1 align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="public/wordmark.svg">
+    <img src="public/wordmark-light.svg" alt="isorouter" height="56">
+  </picture>
+</h1>
 
 [![CI](https://github.com/pidkhvatylin-my/isorouter/actions/workflows/ci.yml/badge.svg)](https://github.com/pidkhvatylin-my/isorouter/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-online-brightgreen.svg)](https://pidkhvatylin-my.github.io/isorouter/)
+
+[![core minzip](https://img.shields.io/bundlephobia/minzip/%40isorouter%2Fcore?label=core%20gzip)](https://bundlephobia.com/package/@isorouter/core)
+[![react minzip](https://img.shields.io/bundlephobia/minzip/%40isorouter%2Freact?label=react%20gzip)](https://bundlephobia.com/package/@isorouter/react)
+[![vue minzip](https://img.shields.io/bundlephobia/minzip/%40isorouter%2Fvue?label=vue%20gzip)](https://bundlephobia.com/package/@isorouter/vue)
+[![svelte gzip](https://img.shields.io/badge/svelte%20gzip-~2.3%20KB-blue.svg)](https://www.npmjs.com/package/@isorouter/svelte)
 
 A lightweight, **framework-agnostic SPA router built on the browser
 [Navigation API](https://developer.mozilla.org/docs/Web/API/Navigation_API)**.
+
+📖 **[Documentation](https://pidkhvatylin-my.github.io/isorouter/)** — guide, framework adapters and full API reference.
 
 The interception, matching, guards, lazy-loading and async-commit state machine
 live in a pure-TypeScript core with **zero framework dependencies**. Thin

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,146 @@
+import { defineConfig } from "vitepress";
+import { transformerTwoslash } from "@shikijs/vitepress-twoslash";
+
+const ogUrl = "https://pidkhvatylin-my.github.io/isorouter/";
+const ogDescription =
+  "A lightweight, framework-agnostic SPA router built on the browser Navigation API. Zero-dependency TypeScript core with thin Svelte 5, React and Vue 3 adapters.";
+
+// https://vitepress.dev/reference/site-config
+export default defineConfig({
+  title: "isorouter",
+  description: ogDescription,
+
+  // Project page lives at https://pidkhvatylin-my.github.io/isorouter/
+  base: "/isorouter/",
+  lang: "en-US",
+  cleanUrls: true,
+  lastUpdated: true,
+  metaChunk: true,
+
+  head: [
+    ["meta", { name: "theme-color", content: "#646cff" }],
+    ["meta", { property: "og:type", content: "website" }],
+    ["meta", { property: "og:title", content: "isorouter" }],
+    ["meta", { property: "og:description", content: ogDescription }],
+    ["meta", { property: "og:url", content: ogUrl }],
+    ["meta", { name: "twitter:card", content: "summary_large_image" }],
+    ["meta", { name: "twitter:title", content: "isorouter" }],
+    ["meta", { name: "twitter:description", content: ogDescription }],
+    [
+      "link",
+      { rel: "icon", type: "image/svg+xml", href: "/isorouter/logo.svg" },
+    ],
+  ],
+
+  markdown: {
+    codeTransformers: [transformerTwoslash()],
+    // Twoslash adds its own language servers; keep these languages aliased so
+    // ```ts twoslash fences resolve cleanly.
+    languages: ["js", "jsx", "ts", "tsx"],
+  },
+
+  themeConfig: {
+    // https://vitepress.dev/reference/default-theme-config
+    logo: { light: "/logo-light.svg", dark: "/logo.svg", alt: "isorouter" },
+    // The default text title is replaced by the two-tone <Wordmark> injected
+    // via the nav-bar-title-after slot (see theme/index.ts).
+    siteTitle: false,
+
+    nav: [
+      { text: "Guide", link: "/guide/introduction", activeMatch: "/guide/" },
+      { text: "API", link: "/api/core", activeMatch: "/api/" },
+      {
+        text: "Frameworks",
+        items: [
+          { text: "Svelte 5", link: "/frameworks/svelte" },
+          { text: "React", link: "/frameworks/react" },
+          { text: "Vue 3", link: "/frameworks/vue" },
+        ],
+      },
+      {
+        text: "v1.0.0",
+        items: [
+          {
+            text: "Changelog",
+            link: "https://github.com/pidkhvatylin-my/isorouter/blob/master/packages/core/CHANGELOG.md",
+          },
+          {
+            text: "Contributing",
+            link: "https://github.com/pidkhvatylin-my/isorouter/blob/master/CONTRIBUTING.md",
+          },
+        ],
+      },
+    ],
+
+    sidebar: {
+      "/guide/": [
+        {
+          text: "Introduction",
+          items: [
+            { text: "What is isorouter?", link: "/guide/introduction" },
+            { text: "Installation", link: "/guide/installation" },
+            { text: "Quick start", link: "/guide/quick-start" },
+          ],
+        },
+        {
+          text: "Core concepts",
+          items: [
+            { text: "Routing & matching", link: "/guide/routing" },
+            { text: "Navigation guards", link: "/guide/guards" },
+            { text: "Lazy loading", link: "/guide/lazy-loading" },
+            { text: "Nested layouts", link: "/guide/nested-layouts" },
+            { text: "Links & active state", link: "/guide/links" },
+            {
+              text: "Type-safe navigation",
+              link: "/guide/type-safe-navigation",
+            },
+            { text: "Browser support", link: "/guide/browser-support" },
+          ],
+        },
+      ],
+      "/frameworks/": [
+        {
+          text: "Framework adapters",
+          items: [
+            { text: "Svelte 5", link: "/frameworks/svelte" },
+            { text: "React", link: "/frameworks/react" },
+            { text: "Vue 3", link: "/frameworks/vue" },
+          ],
+        },
+      ],
+      "/api/": [
+        {
+          text: "API reference",
+          items: [
+            { text: "@isorouter/core", link: "/api/core" },
+            { text: "@isorouter/svelte", link: "/api/svelte" },
+            { text: "@isorouter/react", link: "/api/react" },
+            { text: "@isorouter/vue", link: "/api/vue" },
+          ],
+        },
+      ],
+    },
+
+    socialLinks: [
+      {
+        icon: "github",
+        link: "https://github.com/pidkhvatylin-my/isorouter",
+      },
+    ],
+
+    search: {
+      provider: "local",
+    },
+
+    editLink: {
+      pattern:
+        "https://github.com/pidkhvatylin-my/isorouter/edit/master/docs/:path",
+      text: "Edit this page on GitHub",
+    },
+
+    footer: {
+      message: "Released under the MIT License.",
+      copyright: "Copyright © 2026 Mykhailo Pidkhvatylin",
+    },
+  },
+});

--- a/docs/.vitepress/theme/components/Wordmark.vue
+++ b/docs/.vitepress/theme/components/Wordmark.vue
@@ -1,0 +1,5 @@
+<template>
+  <span class="iso-wordmark"><span class="iso">iso</span><span class="rest"
+      >router</span
+    ></span>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,65 @@
+/**
+ * Brand palette — derived from the logo (periwinkle cube accent #7B8EFB /
+ * highlight #9EABFC; light-theme stroke #4A5CE8). Drives links, buttons, the
+ * hero gradient and active nav state so the whole site matches the mark.
+ */
+:root {
+  --vp-c-brand-1: #4a5ce8;
+  --vp-c-brand-2: #5a6cf5;
+  --vp-c-brand-3: #7b8efb;
+  --vp-c-brand-soft: rgba(123, 142, 251, 0.14);
+
+  /* Home hero gradient on the (replaced) wordmark / accents. */
+  --vp-home-hero-name-color: var(--vp-c-brand-1);
+}
+
+.dark {
+  --vp-c-brand-1: #9eabfc;
+  --vp-c-brand-2: #7b8efb;
+  --vp-c-brand-3: #6b7cfb;
+  --vp-c-brand-soft: rgba(123, 142, 251, 0.18);
+}
+
+/**
+ * The "isorouter" wordmark: "iso" in the brand accent, "router" in the
+ * foreground colour — bold and tightly tracked, matching the logo guide.
+ */
+.iso-wordmark {
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+}
+
+.iso-wordmark .iso {
+  color: var(--vp-c-brand-1);
+}
+
+.iso-wordmark .rest {
+  color: var(--vp-c-text-1);
+}
+
+/* In the nav bar, sit next to the cube logo. */
+.VPNavBarTitle .iso-wordmark {
+  font-size: 18px;
+  margin-left: 8px;
+}
+
+/* In the home hero, stand in for the default name as the headline mark. */
+.iso-wordmark--hero {
+  display: block;
+  font-size: 52px;
+  line-height: 1.1;
+  margin-bottom: 6px;
+}
+
+@media (min-width: 640px) {
+  .iso-wordmark--hero {
+    font-size: 64px;
+  }
+}
+
+@media (min-width: 960px) {
+  .iso-wordmark--hero {
+    font-size: 72px;
+  }
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,23 @@
+import { h } from "vue";
+import type { Theme } from "vitepress";
+import DefaultTheme from "vitepress/theme";
+import TwoslashFloatingVue from "@shikijs/vitepress-twoslash/client";
+import "@shikijs/vitepress-twoslash/style.css";
+import "./custom.css";
+import Wordmark from "./components/Wordmark.vue";
+
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      // Brand wordmark next to the cube logo in the nav bar.
+      "nav-bar-title-after": () => h(Wordmark),
+      // …and standing in for the default name in the home hero.
+      "home-hero-info-before": () =>
+        h(Wordmark, { class: "iso-wordmark--hero" }),
+    });
+  },
+  enhanceApp({ app }) {
+    app.use(TwoslashFloatingVue);
+  },
+} satisfies Theme;

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,0 +1,210 @@
+# @isorouter/core
+
+The framework-agnostic core: matcher, guards, lazy loading and the async-commit
+state machine. Zero runtime dependencies.
+
+```sh
+npm install @isorouter/core
+```
+
+## `createCoreRouter(routes, options?)`
+
+Creates a router. A thin wrapper around `new Router(routes, options)`.
+
+```ts twoslash
+// @filename: User.ts
+export default {};
+// @filename: index.ts
+import { createCoreRouter, lazy } from "@isorouter/core";
+
+declare const Home: unknown;
+declare const Concerts: unknown;
+// ---cut---
+const router = createCoreRouter([
+  { path: "/", component: Home },
+  { path: "/concerts/:city", component: Concerts },
+  { path: "/users/:id", component: lazy(() => import("./User")) },
+] as const);
+```
+
+Declare routes `as const` to unlock [type-safe
+navigation](../guide/type-safe-navigation).
+
+## The external-store contract
+
+The router publishes state as an **immutable snapshot** — a fresh object
+reference on every commit, stable in between.
+
+- `router.subscribe(fn)` — registers `fn(snapshot)`, returns an unsubscribe.
+- `router.getSnapshot()` — the current snapshot (referentially stable until the
+  next commit).
+
+This is the lowest common denominator across reactivity systems: it plugs
+straight into React's `useSyncExternalStore`, Svelte 5's `createSubscriber`,
+Vue's `shallowRef`, or anything else that reacts to a changed reference.
+
+## Instance methods
+
+### Navigation
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+const router = createCoreRouter([{ path: "/concerts/:city" }] as const);
+// ---cut---
+router.navigate("/concerts/kyiv");
+router.navigate("/concerts/kyiv", { replace: true, state: { from: "search" } });
+router.back();
+router.forward();
+```
+
+`navigate` **throws** if `navigation` is unavailable (no polyfill loaded).
+`back` and `forward` are **no-ops** in that case. See
+[Browser support](../guide/browser-support).
+
+### `isActive(path, options?)`
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+const router = createCoreRouter([{ path: "/concerts/:city" }] as const);
+// ---cut---
+router.isActive("/concerts"); // true for "/concerts" and "/concerts/kyiv"
+router.isActive("/concerts", { exact: true }); // true only for "/concerts"
+```
+
+### Lifecycle
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+const router = createCoreRouter([{ path: "/" }] as const);
+// ---cut---
+router.start(); // begins intercepting same-origin navigations
+router.stop(); // removes the listener, aborts any in-flight commit
+```
+
+`start()` is a no-op if `navigation` is unavailable. Adapters call `start`/`stop`
+for you on mount/unmount.
+
+## Types
+
+### `RouteConfig`
+
+```ts twoslash
+type Awaitable<T> = T | Promise<T>;
+interface GuardContext {
+  params: Record<string, string>;
+  url: URL;
+  pathname: string;
+  signal: AbortSignal;
+  navigationType: "reload" | "push" | "replace" | "traverse";
+}
+type BeforeLoad = (ctx: GuardContext) => Awaitable<void | boolean | string>;
+interface LazyComponent<C> {
+  (): Promise<{ default: C }>;
+}
+// ---cut---
+interface RouteConfig<C = unknown> {
+  path?: string;
+  index?: boolean;
+  component?: C | LazyComponent<C>;
+  beforeLoad?: BeforeLoad;
+  title?: string | ((ctx: GuardContext) => string);
+  children?: readonly RouteConfig<C>[];
+}
+```
+
+- **`path`** — `"users/:id"` for a param, `"files/*"` for a catch-all splat
+  (`params["*"]` gets the remaining path, decoded). Static > param > splat,
+  regardless of declaration order; ties broken by source order.
+- **`index`** — matches when the parent's path is matched exactly (no remaining
+  segments).
+- **`component`** — a value, or `lazy(() => import("./Page"))`. Routes with no
+  `component` are matched (e.g. as pass-through layouts) but contribute nothing
+  to `snapshot.components`.
+- **`children`** — nested routes. A matched parent with no matching child still
+  resolves on its own if the path is fully consumed.
+- **`title`** — sets `document.title` on commit. The **deepest** route in the
+  matched chain that defines a `title` wins.
+
+### `RouterSnapshot`
+
+```ts twoslash
+interface RouterSnapshot<C> {
+  /** Matched chain's components, root → leaf (routes with no component removed). */
+  components: C[];
+  params: Record<string, string>;
+  url: URL;
+  status: "idle" | "navigating" | "not-found" | "error";
+  error: unknown;
+}
+```
+
+### `GuardContext` & `BeforeLoad`
+
+```ts twoslash
+type Awaitable<T> = T | Promise<T>;
+// ---cut---
+interface GuardContext {
+  params: Record<string, string>;
+  url: URL;
+  pathname: string;
+  /** Aborts when this navigation is superseded by a newer one. */
+  signal: AbortSignal;
+  navigationType: "reload" | "push" | "replace" | "traverse";
+}
+
+type BeforeLoad = (ctx: GuardContext) => Awaitable<void | boolean | string>;
+```
+
+Return nothing/`true` to allow, `false` to block (current URL restored), or a
+`string` to redirect (`replace`). See [Navigation guards](../guide/guards).
+
+## `lazy(loader)`
+
+```ts twoslash
+// @filename: User.ts
+export default {};
+// @filename: index.ts
+import { lazy } from "@isorouter/core";
+// ---cut---
+const User = lazy(() => import("./User"));
+```
+
+The dynamic import runs **once** on first match; its `default` export is cached
+for subsequent navigations. `isLazy(value)` narrows a value to a
+`LazyComponent`. See [Lazy loading](../guide/lazy-loading).
+
+## Options
+
+```ts twoslash
+interface RouterSnapshot<C> {
+  components: C[];
+  params: Record<string, string>;
+  url: URL;
+  status: "idle" | "navigating" | "not-found" | "error";
+  error: unknown;
+}
+// ---cut---
+interface RouterOptions {
+  scroll?: "after-transition" | "manual";
+  onError?: (err: unknown) => void;
+  onCommit?: (snapshot: RouterSnapshot<unknown>) => void;
+}
+```
+
+- **`scroll`** — `"after-transition"` (default) restores/resets scroll once the
+  commit settles; `"manual"` leaves scroll to you.
+- **`onError`** — called with any error thrown during a guard or lazy import.
+- **`onCommit`** — called with each committed snapshot.
+
+## Exports
+
+`createCoreRouter`, `Router`, `matchRoutes`, `lazy`, `isLazy`, and the types
+`AnyRouter`, `Unsubscribe`, `LazyComponent`, `Awaitable`, `BeforeLoad`,
+`ExtractParams`, `GuardContext`, `Href`, `NavTarget`, `NavigationKind`,
+`RouteConfig`, `RouteMatch`, `RouteTemplate`, `RouterOptions`, `RouterSnapshot`.
+
+## Other targets (TypeScript)
+
+`@isorouter/core` targets **TypeScript ≥ 6.0**, whose `lib.dom.d.ts` ships the
+Navigation API types — no extra `@types` package needed. On TypeScript < 6,
+install `@types/dom-navigation`. See [Installation](../guide/installation#typescript-6-0).

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -1,0 +1,53 @@
+# @isorouter/react
+
+React adapter. **Requires React ≥ 18.** For a walkthrough see the
+[React guide](../frameworks/react).
+
+```sh
+npm install @isorouter/react
+```
+
+## Exports
+
+| Export            | Kind      | Description                                                            |
+| ----------------- | --------- | --------------------------------------------------------------------- |
+| `createRouter`    | function  | `createCoreRouter` with the component type fixed to a React `ComponentType`. |
+| `Router`          | component | Root component — calls `start`/`stop`, renders matched component or `loading`/`notFound`/`error`. |
+| `Outlet`          | component | Renders the next component in the matched chain; nothing if no child. |
+| `Link`            | component | A plain `<a>` intercepted by the Navigation API; forwards `ref`.      |
+| `useRouter`       | hook      | The `Router` instance.                                                |
+| `useRouterState`  | hook      | Current `RouterSnapshot`, re-rendering on every commit.               |
+| `useParams`       | hook      | `snapshot.params`, typed as `P`.                                      |
+| `useLocation`     | hook      | `snapshot.url`.                                                       |
+| `useNavigate`     | hook      | Referentially-stable `(to, opts?) => void`.                          |
+| `lazy`            | function  | Re-exported from `@isorouter/core`.                                   |
+
+## Types
+
+`RouterProps`, `LinkProps`, plus the core re-exports `BeforeLoad`,
+`GuardContext`, `Href`, `NavTarget`, `RouteConfig`, `RouterOptions`,
+`RouterSnapshot`.
+
+## `<Router>` props
+
+| Prop       | Type                          | Shown when                                            |
+| ---------- | ----------------------------- | ---------------------------------------------------- |
+| `router`   | `Router` instance             | —                                                    |
+| `loading`  | `ReactNode`                   | no matched root component yet; no `error`/`notFound` applies. |
+| `notFound` | `ReactNode`                   | `snapshot.status === "not-found"`.                   |
+| `error`    | `(err: unknown) => ReactNode` | `snapshot.status === "error"`.                       |
+
+## `<Link>` props
+
+Extends `AnchorHTMLAttributes<HTMLAnchorElement>`. Adds `href`,
+`activeClassName` (default `"active"`, appended to `className`) and `exact`. Sets
+`aria-current="page"` when active. See [Links & active state](../guide/links).
+
+## Hooks
+
+All must be used within `<Router>`. `useNavigate()` is **referentially stable**,
+so it's safe in dependency arrays without re-subscribing.
+
+> Bridge primitive: `useSyncExternalStore(subscribe, getSnapshot)` — detects
+> change via `Object.is(prev, next)`, which the immutable-snapshot contract
+> satisfies with a fresh reference per commit.

--- a/docs/api/svelte.md
+++ b/docs/api/svelte.md
@@ -1,0 +1,50 @@
+# @isorouter/svelte
+
+Svelte 5 adapter. **Requires Svelte ≥ 5.7.** For a walkthrough see the
+[Svelte guide](../frameworks/svelte).
+
+```sh
+npm install @isorouter/svelte
+```
+
+## Exports
+
+| Export             | Kind      | Description                                                            |
+| ------------------ | --------- | --------------------------------------------------------------------- |
+| `createRouter`     | function  | `createCoreRouter` with the component type fixed to Svelte's `Component`; returns a `SvelteRouter`. |
+| `SvelteRouter`     | class     | The reactive wrapper around the core router.                          |
+| `Router`           | component | Root component — calls `start`/`stop`, renders matched component or `loading`/`notFound`/`error` snippets. |
+| `Outlet`           | component | Renders the next component in the matched chain; nothing if no child. |
+| `Link`             | component | A plain `<a>` intercepted by the Navigation API.                      |
+| `getRouter`        | function  | Reads the `SvelteRouter` from context (within `<Router>`/`<Outlet>`). |
+| `lazy`             | function  | Re-exported from `@isorouter/core`.                                   |
+
+## Types
+
+`AnySvelteRouter`, `SvelteComponentType`, plus the core re-exports `BeforeLoad`,
+`GuardContext`, `Href`, `NavTarget`, `RouteConfig`, `RouterOptions`,
+`RouterSnapshot`.
+
+## `<Router>` snippets
+
+| Snippet     | Shown when                                                              |
+| ----------- | --------------------------------------------------------------------- |
+| `loading`   | no matched root component yet, and neither `error` nor `notFound` applies. |
+| `notFound`  | `router.current.status === "not-found"`.                               |
+| `error(err)`| `router.current.status === "error"` — receives `router.current.error`. |
+
+## `<Link>` props
+
+`href`, `class` (merged with `activeClass`), `activeClass` (default `"active"`),
+`exact`. Sets `aria-current="page"` when active. Other attributes forwarded to
+the `<a>`. See [Links & active state](../guide/links).
+
+## `getRouter()`
+
+Returns the `SvelteRouter`. `router.current` is a getter — read it inside a
+`$derived`, `$effect` or the template to subscribe to commits; the subscription
+drops once nothing reads it. `router.navigate`, `router.back`, `router.forward`
+and `router.isActive` are available on the instance too.
+
+> Bridge primitive: Svelte 5's `createSubscriber` — the subscription is live
+> only while `current` is read in a reactive scope, and is auto-torn-down.

--- a/docs/api/vue.md
+++ b/docs/api/vue.md
@@ -1,0 +1,52 @@
+# @isorouter/vue
+
+Vue 3 adapter. **Requires Vue ≥ 3.4.** For a walkthrough see the
+[Vue guide](../frameworks/vue).
+
+```sh
+npm install @isorouter/vue
+```
+
+## Exports
+
+| Export            | Kind        | Description                                                            |
+| ----------------- | ----------- | --------------------------------------------------------------------- |
+| `createRouter`    | function    | `createCoreRouter` with the component type fixed to Vue's `Component`. |
+| `RouterView`      | component   | Root component — calls `start`/`stop`, renders matched component or `loading`/`notFound`/`error` slots. |
+| `Outlet`          | component   | Renders the next component in the matched chain; nothing if no child. |
+| `Link`            | component   | A plain `<a>` intercepted by the Navigation API.                      |
+| `useRouter`       | composable  | The `Router` instance.                                                |
+| `useRouterState`  | composable  | `ShallowRef<RouterSnapshot>`; fresh reference on every commit.        |
+| `useParams`       | composable  | `ComputedRef<Record<string, string>>`.                               |
+| `useLocation`     | composable  | `ComputedRef<URL>`.                                                   |
+| `useNavigate`     | composable  | `(to, opts?) => void` delegating to `router.navigate`.               |
+| `lazy`            | function    | Re-exported from `@isorouter/core`.                                   |
+
+## Types
+
+Core re-exports: `BeforeLoad`, `GuardContext`, `Href`, `NavTarget`,
+`RouteConfig`, `RouterOptions`, `RouterSnapshot`.
+
+## `<RouterView>` slots
+
+| Slot       | Shown when                                                              |
+| ---------- | --------------------------------------------------------------------- |
+| `loading`  | no matched root component yet; no `error`/`notFound` applies.          |
+| `notFound` | `snapshot.status === "not-found"`.                                     |
+| `error`    | `snapshot.status === "error"` — receives `{ error: snapshot.error }`.  |
+
+## `<Link>` props
+
+`href`, `activeClass` (default `"active"`, applied as the element's `class`),
+`exact`. Sets `aria-current="page"` when active; default slot is rendered as the
+link's children. Must be used within `<RouterView>`. See
+[Links & active state](../guide/links).
+
+## Composables
+
+All must be used within `<RouterView>` (they `inject` the provided router).
+`useRouterState()`'s subscription is torn down automatically via
+`onScopeDispose`.
+
+> Bridge primitive: `shallowRef(snapshot)` + `subscribe` — the snapshot is
+> already immutable, so shallow-ref replacement is exactly right (no deep proxy).

--- a/docs/frameworks/react.md
+++ b/docs/frameworks/react.md
@@ -1,0 +1,118 @@
+# React
+
+`@isorouter/react` wraps the core router's immutable-snapshot external store
+with `useSyncExternalStore`, so navigation re-renders stay correct and tear-free
+under React 18's concurrent renderer.
+
+**Requires React ≥ 18.** `@isorouter/core` is installed automatically.
+
+```sh
+npm install @isorouter/react
+```
+
+## Quick start
+
+```tsx
+import { createRoot } from "react-dom/client";
+import { createRouter, Router, Outlet } from "@isorouter/react";
+
+const router = createRouter([
+  { path: "/", component: Home },
+  { path: "about", component: About },
+  {
+    path: "dashboard",
+    component: DashboardLayout,
+    children: [
+      { index: true, component: Overview },
+      { path: "settings", component: Settings },
+    ],
+  },
+] as const);
+
+function DashboardLayout() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <Outlet />
+    </div>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(
+  <Router router={router} notFound={<p>Not found</p>} />,
+);
+```
+
+`createRouter` is `createCoreRouter` with the component type fixed to a React
+`ComponentType`. `<Router>` calls `router.start()` on mount and `router.stop()`
+on unmount.
+
+## Components
+
+### `<Router>`
+
+```tsx
+<Router
+  router={router}
+  loading={<Spinner />}
+  notFound={<NotFound />}
+  error={(err) => <ErrorPage error={err} />}
+/>
+```
+
+- `notFound` — rendered when `snapshot.status === "not-found"`.
+- `error` — called with `snapshot.error` when `snapshot.status === "error"`.
+- `loading` — when there's no matched root component yet (e.g. before the first
+  commit) and neither `error` nor `notFound` applies.
+
+Otherwise renders the root matched component, `snapshot.components[0]`.
+
+### `<Outlet>`
+
+Renders the next component in the matched chain at the current nesting depth;
+renders nothing when there's no matching child. Use it inside a layout.
+
+### `<Link>`
+
+```tsx
+<Link href="/dashboard" activeClassName="active" exact>
+  Dashboard
+</Link>
+```
+
+A plain `<a>` intercepted by the Navigation API — extends
+`AnchorHTMLAttributes<HTMLAnchorElement>` and forwards `ref` and any other
+props. `activeClassName` is appended to `className` when
+`router.isActive(href, { exact })` (default `"active"`); when active, also sets
+`aria-current="page"`. See [Links & active state](../guide/links).
+
+## Hooks
+
+All hooks must be used within `<Router>`.
+
+| Hook                 | Returns                                                                        |
+| -------------------- | ----------------------------------------------------------------------------- |
+| `useRouter()`        | the `Router` instance.                                                         |
+| `useRouterState()`   | the current `RouterSnapshot`, re-rendering on every commit.                    |
+| `useParams<P>()`     | `snapshot.params`, typed as `P`.                                               |
+| `useLocation()`      | `snapshot.url`.                                                                |
+| `useNavigate()`      | a referentially-stable `(to, opts?) => void` bound to `router.navigate`.       |
+
+```tsx
+import { useParams, useNavigate } from "@isorouter/react";
+
+function User() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  return <button onClick={() => navigate("/")}>User {id} — go home</button>;
+}
+```
+
+`useNavigate()` is referentially stable, so it's safe in `useEffect` dependency
+arrays and `useCallback` bodies without re-subscribing.
+
+## See also
+
+- [Type-safe navigation](../guide/type-safe-navigation)
+- [Nested layouts](../guide/nested-layouts)
+- [`@isorouter/react` API reference](../api/react)

--- a/docs/frameworks/svelte.md
+++ b/docs/frameworks/svelte.md
@@ -1,0 +1,134 @@
+# Svelte 5
+
+`@isorouter/svelte` wraps the core router's immutable-snapshot external store
+with Svelte 5's `createSubscriber`: reading `router.current` inside a
+`$derived`, `$effect` or the template subscribes to commits, and the
+subscription is torn down automatically once nothing reads it anymore — no
+manual `$effect`, no leaks.
+
+**Requires Svelte ≥ 5.7.** `@isorouter/core` is installed automatically.
+
+```sh
+npm install @isorouter/svelte
+```
+
+## Quick start
+
+```ts
+// main.ts
+import { mount } from "svelte";
+import { createRouter } from "@isorouter/svelte";
+
+import App from "./App.svelte";
+import Home from "./Home.svelte";
+import About from "./About.svelte";
+import DashboardLayout from "./DashboardLayout.svelte";
+import Overview from "./Overview.svelte";
+import Settings from "./Settings.svelte";
+
+export const router = createRouter([
+  { path: "/", component: Home },
+  { path: "about", component: About },
+  {
+    path: "dashboard",
+    component: DashboardLayout,
+    children: [
+      { index: true, component: Overview },
+      { path: "settings", component: Settings },
+    ],
+  },
+] as const);
+
+mount(App, { target: document.getElementById("app")!, props: { router } });
+```
+
+```svelte
+<!-- App.svelte -->
+<script lang="ts">
+  import { Router } from "@isorouter/svelte";
+  import type { AnySvelteRouter } from "@isorouter/svelte";
+
+  let { router }: { router: AnySvelteRouter } = $props();
+</script>
+
+<Router {router}>
+  {#snippet notFound()}<p>Not found</p>{/snippet}
+</Router>
+```
+
+`createRouter` returns a `SvelteRouter` wrapping the core router, with the
+component type fixed to Svelte's `Component`. `<Router>` calls `router.start()`
+on mount and `router.stop()` on unmount.
+
+## Components
+
+### `<Router>`
+
+Mount once near the app root. Provide UI for the non-content states via
+snippets:
+
+```svelte
+<Router {router}>
+  {#snippet loading()}<Spinner />{/snippet}
+  {#snippet notFound()}<NotFound />{/snippet}
+  {#snippet error(err)}<ErrorPage error={err} />{/snippet}
+</Router>
+```
+
+- `notFound` — `router.current.status === "not-found"`.
+- `error` — called with `router.current.error` when status is `"error"`.
+- `loading` — when there's no matched root component yet (e.g. before the first
+  commit) and neither `error` nor `notFound` applies.
+
+Otherwise it renders the root matched component, `router.current.components[0]`.
+
+### `<Outlet>`
+
+Renders the next component in the matched chain at the current nesting depth;
+renders nothing when there's no matching child.
+
+```svelte
+<!-- DashboardLayout.svelte -->
+<script lang="ts">
+  import { Outlet } from "@isorouter/svelte";
+</script>
+
+<h1>Dashboard</h1>
+<Outlet />
+```
+
+### `<Link>`
+
+```svelte
+<Link href="/dashboard" activeClass="active" exact>Dashboard</Link>
+```
+
+A plain `<a>` intercepted by the Navigation API. `activeClass` is appended to
+`class` when `router.isActive(href, { exact })` (default `"active"`); `exact`
+requires an exact match. When active, also sets `aria-current="page"`. Must be
+used within `<Router>` (or `<Outlet>`). See [Links & active state](../guide/links).
+
+## `getRouter()`
+
+Reads the `SvelteRouter` from context. Must be used within `<Router>` (or
+`<Outlet>`):
+
+```svelte
+<script lang="ts">
+  import { getRouter } from "@isorouter/svelte";
+  const router = getRouter();
+</script>
+
+<p>{router.current.params.city}</p>
+```
+
+`router.current` is a **getter** — read it inside a `$derived`, `$effect` or the
+template to subscribe to commits; the subscription is dropped once nothing reads
+it. `router.navigate`, `router.back`, `router.forward` and `router.isActive` are
+also available on the instance.
+
+## See also
+
+- [Type-safe navigation](../guide/type-safe-navigation)
+- [Nested layouts](../guide/nested-layouts)
+- [`@isorouter/svelte` API reference](../api/svelte)

--- a/docs/frameworks/vue.md
+++ b/docs/frameworks/vue.md
@@ -1,0 +1,119 @@
+# Vue 3
+
+`@isorouter/vue` wraps the core router's immutable-snapshot external store with
+`shallowRef`, so navigation updates stay correct and reactive. The snapshot is
+already immutable, so shallow-ref replacement is exactly right — no deep proxy.
+
+**Requires Vue ≥ 3.4.** `@isorouter/core` is installed automatically.
+
+```sh
+npm install @isorouter/vue
+```
+
+## Quick start
+
+```ts
+import { createApp, defineComponent, h } from "vue";
+import { createRouter, RouterView, Outlet } from "@isorouter/vue";
+
+const router = createRouter([
+  { path: "/", component: Home },
+  { path: "about", component: About },
+  {
+    path: "dashboard",
+    component: DashboardLayout,
+    children: [
+      { index: true, component: Overview },
+      { path: "settings", component: Settings },
+    ],
+  },
+] as const);
+
+const DashboardLayout = defineComponent({
+  render: () => h("div", [h("h1", "Dashboard"), h(Outlet)]),
+});
+
+const App = defineComponent({
+  render: () =>
+    h(RouterView, { router }, { notFound: () => h("p", "Not found") }),
+});
+
+createApp(App).mount("#app");
+```
+
+`createRouter` is `createCoreRouter` with the component type fixed to Vue's
+`Component`. `<RouterView>` calls `router.start()` on mount and `router.stop()`
+on unmount.
+
+::: tip SFC templates
+The examples here use the render-function form so they're framework-portable,
+but everything works identically in `<template>` SFCs:
+`<RouterView :router="router">`, `<Outlet />`, `<Link href="/about">`.
+:::
+
+## Components
+
+### `<RouterView>`
+
+Root component. Mount once near the app root and pass the router via the
+`router` prop, with optional named slots:
+
+```ts
+h(
+  RouterView,
+  { router },
+  {
+    loading: () => h(Spinner),
+    notFound: () => h(NotFound),
+    error: ({ error }) => h(ErrorPage, { error }),
+  },
+);
+```
+
+- `notFound` — rendered when `snapshot.status === "not-found"`.
+- `error` — called with `{ error: snapshot.error }` when status is `"error"`.
+- `loading` — when there's no matched root component yet (e.g. before the first
+  commit) and neither `error` nor `notFound` applies.
+
+Otherwise renders the root matched component, `snapshot.components[0]`.
+
+### `<Outlet>`
+
+Renders the next component in the matched chain at the current nesting depth;
+renders nothing when there's no matching child. Use it inside a layout.
+
+### `<Link>`
+
+```ts
+h(Link, { href: "/dashboard", activeClass: "active", exact: true }, () =>
+  "Dashboard",
+);
+```
+
+A plain `<a>` intercepted by the Navigation API. `activeClass` is applied as the
+element's `class` when `router.isActive(href, { exact })` (default `"active"`);
+when active, also sets `aria-current="page"`. Slot content is rendered as the
+link's children. Must be used within `<RouterView>`. See
+[Links & active state](../guide/links).
+
+## Composables
+
+All composables must be used within `<RouterView>` (they `inject` the router
+provided there).
+
+| Composable           | Returns                                                                |
+| -------------------- | --------------------------------------------------------------------- |
+| `useRouter()`        | the `Router` instance.                                                 |
+| `useRouterState()`   | a `ShallowRef<RouterSnapshot>`; fresh reference on every commit.       |
+| `useParams()`        | a `ComputedRef<Record<string, string>>` of the current params.        |
+| `useLocation()`      | a `ComputedRef<URL>` of the current location.                          |
+| `useNavigate()`      | `(to, opts?) => void` delegating to `router.navigate`.                 |
+
+`useRouterState()`'s subscription is torn down automatically via
+`onScopeDispose`.
+
+## See also
+
+- [Type-safe navigation](../guide/type-safe-navigation)
+- [Nested layouts](../guide/nested-layouts)
+- [`@isorouter/vue` API reference](../api/vue)

--- a/docs/guide/browser-support.md
+++ b/docs/guide/browser-support.md
@@ -1,0 +1,62 @@
+# Browser support
+
+isorouter is built directly on the browser
+[Navigation API](https://developer.mozilla.org/docs/Web/API/Navigation_API).
+There is **no History API fallback** — that's a deliberate design choice, not
+an omission.
+
+## Baseline status
+
+The Navigation API reached **Baseline Newly available** in early 2026 (Chrome,
+Edge, Firefox, Safari). It is **not yet Widely available**, so browsers still
+in production from before then lack it.
+
+::: warning Supported contract
+The supported contract is the **pure Navigation API**. If a browser has it,
+isorouter works. If it doesn't, load a polyfill (below) — but the polyfill is
+**best-effort**, with known gaps. isorouter does not ship or maintain its own
+History-based shim.
+:::
+
+## Polyfill (opt-in)
+
+If you must support pre-2026 engines, load a polyfill **before** starting the
+router (the "unix way": one small dependency, opt-in):
+
+```ts twoslash
+// @noErrors
+declare const router: { start(): void };
+// ---cut---
+if (!window.navigation) {
+  const { applyPolyfill } = await import(
+    "@virtualstate/navigation/apply-polyfill"
+  );
+  applyPolyfill();
+}
+router.start(); // or mount <Router> / <RouterView>
+```
+
+[`@virtualstate/navigation`](https://github.com/virtualstate/navigation) is the
+only polyfill we're aware of that implements `navigate` + `event.intercept()`,
+which isorouter's interception model depends on. The e2e suite runs the full
+test matrix a **second time** with the native Navigation API hidden, against
+this polyfill, to verify behavioural parity.
+
+### Known limitation
+
+As of `@virtualstate/navigation@1.0.1-alpha.212`, `interceptWindowClicks`
+reports `downloadRequest: ""` (instead of `null`) for plain `<a>` clicks, so the
+`navigate` event isn't intercepted and the polyfill falls back to a full-page
+navigation for **link clicks**. The route still renders correctly (the fresh
+page load re-runs `router.start()`), but the transition isn't client-side.
+
+**Imperative navigation** — `router.navigate`, `back`, `forward`, guards,
+redirects, lazy loading — is unaffected and works identically to native.
+
+## What happens with no Navigation API and no polyfill
+
+- `router.start()` is a **no-op**.
+- `router.navigate(...)` **throws**.
+- `router.back()` / `router.forward()` are **no-ops**.
+
+So a feature-detect like the snippet above is all you need to degrade safely.

--- a/docs/guide/guards.md
+++ b/docs/guide/guards.md
@@ -1,0 +1,86 @@
+# Navigation guards
+
+A route can declare a `beforeLoad` guard. Guards run **root → leaf** over the
+matched chain **before any component commits**, so a blocked or redirected
+navigation never flashes the target UI.
+
+## Signature
+
+```ts twoslash
+type Awaitable<T> = T | Promise<T>;
+
+interface GuardContext {
+  params: Record<string, string>;
+  url: URL;
+  pathname: string;
+  /** Aborts when this navigation is superseded by a newer one. */
+  signal: AbortSignal;
+  navigationType: "reload" | "push" | "replace" | "traverse";
+}
+
+type BeforeLoad = (ctx: GuardContext) => Awaitable<void | boolean | string>;
+```
+
+## Return values
+
+| Return            | Effect                                                |
+| ----------------- | ----------------------------------------------------- |
+| `undefined` / `true` | **Allow** the navigation.                          |
+| `false`           | **Block** — the current URL is restored.              |
+| `string`          | **Redirect** (via `replace`) to that path.            |
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+
+declare const Dashboard: unknown;
+declare function isLoggedIn(): boolean;
+// ---cut---
+const router = createCoreRouter([
+  {
+    path: "/dashboard",
+    component: Dashboard,
+    beforeLoad: () => {
+      if (!isLoggedIn()) return "/login"; // redirect
+    },
+  },
+] as const);
+```
+
+## Async guards & the abort signal
+
+Guards can be `async`. Because navigations can be superseded (the user clicks
+another link mid-flight), the context carries an `AbortSignal` that fires when
+**this** navigation is no longer the latest. Forward it to `fetch` and bail out
+on abort:
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+
+declare const Profile: unknown;
+// ---cut---
+const router = createCoreRouter([
+  {
+    path: "/profile/:id",
+    component: Profile,
+    beforeLoad: async (ctx) => {
+      const res = await fetch(`/api/users/${ctx.params.id}`, {
+        signal: ctx.signal,
+      });
+      if (res.status === 404) return false; // block: restore current URL
+    },
+  },
+] as const);
+```
+
+::: tip
+Guards run **root → leaf**: a parent layout's guard runs before its children's.
+This makes the parent the natural place for shared auth checks — children only
+add what's specific to them.
+:::
+
+## Errors
+
+If a guard throws (or a lazy import rejects), the snapshot transitions to
+`status: "error"` and `snapshot.error` holds the thrown value. The adapters
+render their `error` slot/prop for it — see the framework guides. You can also
+observe errors globally via the `onError` [option](../api/core#options).

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,0 +1,78 @@
+# Installation
+
+Pick the package for your framework. Each adapter declares `@isorouter/core`
+as a regular dependency, so it's installed automatically.
+
+::: code-group
+
+```sh [core (any / none)]
+npm install @isorouter/core
+```
+
+```sh [Svelte 5]
+npm install @isorouter/svelte
+```
+
+```sh [React]
+npm install @isorouter/react
+```
+
+```sh [Vue 3]
+npm install @isorouter/vue
+```
+
+:::
+
+## Requirements
+
+### Navigation API
+
+isorouter is built on the browser
+[Navigation API](https://developer.mozilla.org/docs/Web/API/Navigation_API). It
+reached **Baseline Newly available** in early 2026 (Chrome, Edge, Firefox,
+Safari) but is **not yet Widely available**.
+
+isorouter ships **no History API fallback** by design. If you need to support
+older engines, load a polyfill before starting the router — see
+[Browser support](./browser-support) for the full story.
+
+### TypeScript ≥ 6.0
+
+For full type support, use **TypeScript 6.0 or newer**. Its `lib.dom.d.ts`
+ships the Navigation API types (`Navigation`, `NavigateEvent`,
+`NavigationResult`, the global `navigation`), so **no extra `@types` package is
+needed**.
+
+On TypeScript < 6, install `@types/dom-navigation` yourself.
+
+### Framework versions
+
+| Adapter             | Peer requirement |
+| ------------------- | ---------------- |
+| `@isorouter/svelte` | Svelte ≥ 5.7     |
+| `@isorouter/react`  | React ≥ 18       |
+| `@isorouter/vue`    | Vue ≥ 3.4        |
+
+## Bundle size
+
+Every package is ESM-only with `"sideEffects": false` for full tree-shaking.
+Measured by [Bundlephobia](https://bundlephobia.com/package/@isorouter/core)
+(minified / minified + gzipped); adapter figures **include** the core:
+
+| Package              | Minified | Gzipped |
+| -------------------- | -------- | ------- |
+| `@isorouter/core`    | ~4.0 KB  | ~1.8 KB |
+| `@isorouter/react`   | ~5.4 KB  | ~2.3 KB |
+| `@isorouter/vue`     | ~5.6 KB  | ~2.3 KB |
+| `@isorouter/svelte`  | —        | ~2.3 KB\* |
+
+`@isorouter/core` has **zero runtime dependencies**; the adapters add only
+their bridge code on top (~0.5 KB gzipped each).
+
+\* Bundlephobia can't build Svelte's compiled `.svelte` exports, so the Svelte
+figure is an estimate (core ~1.8 KB + adapter ~0.5 KB), in line with the React
+and Vue adapters.
+
+## Next
+
+Head to the [Quick start](./quick-start) for a running router.

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,0 +1,56 @@
+# What is isorouter?
+
+**isorouter** is a lightweight, framework-agnostic SPA router built on the
+browser [Navigation API](https://developer.mozilla.org/docs/Web/API/Navigation_API).
+
+The interception, matching, guards, lazy-loading and async-commit state machine
+live in a pure-TypeScript core with **zero framework dependencies**. Thin
+adapters bind that core into Svelte 5, React and Vue 3.
+
+```
+@isorouter/core     ← pure TS: matcher, guards, lazy, commit state machine
+   ├── @isorouter/svelte   ← createSubscriber bridge
+   ├── @isorouter/react    ← useSyncExternalStore bridge
+   └── @isorouter/vue      ← shallowRef bridge
+```
+
+## Why this shape
+
+The core is an **external store**: it exposes `subscribe(fn)` + `getSnapshot()`
+and publishes an **immutable snapshot with a fresh reference on every commit**.
+That contract is the lowest common denominator across the three reactivity
+systems — each adapter wraps it with the framework's native primitive:
+
+| Framework | Bridge primitive                                | Why                                                                                   |
+| --------- | ----------------------------------------------- | ------------------------------------------------------------------------------------- |
+| React     | `useSyncExternalStore(subscribe, getSnapshot)`  | Detects change via `Object.is(prev, next)` — **requires** a new reference per update.  |
+| Svelte 5  | `createSubscriber(update => subscribe(update))` | Subscription is live only while `current` is read in a reactive scope; auto-torn-down. |
+| Vue 3     | `shallowRef(snapshot)` + `subscribe`            | Snapshot is already immutable, so shallow ref replacement is exactly right.            |
+
+::: tip A Proxy-based core was considered and rejected
+A `Proxy` that mutates in place keeps the **same reference**, so
+`useSyncExternalStore` would never see a change and React would not re-render.
+The immutable-snapshot contract is what makes **one core serve all three
+frameworks**.
+:::
+
+## Design principles
+
+- **The platform does the hard part.** Click interception, history entries,
+  scroll restoration and focus are the browser's job via the Navigation API —
+  isorouter orchestrates matching and commits on top, it doesn't reimplement
+  the history stack.
+- **No History API fallback by design.** isorouter targets the Navigation API
+  directly. If you must support pre-2026 engines, load a polyfill before
+  starting the router — see [Browser support](./browser-support).
+- **Type-safety is not bolted on.** Declaring routes `as const` makes
+  `navigate` reject unknown paths at compile time. See
+  [Type-safe navigation](./type-safe-navigation).
+- **Small and tree-shakeable.** The core is a single ESM file (~4 KB minified /
+  1.8 KB gzipped) with zero runtime dependencies and `"sideEffects": false`.
+
+## Next steps
+
+- [Installation](./installation) — pick the package for your framework.
+- [Quick start](./quick-start) — a running router in a few lines.
+- [Type-safe navigation](./type-safe-navigation) — the headline TypeScript feature.

--- a/docs/guide/lazy-loading.md
+++ b/docs/guide/lazy-loading.md
@@ -1,0 +1,63 @@
+# Lazy loading
+
+Wrap a dynamic `import()` in `lazy()` to code-split a route. The chunk loads on
+**first match** and the resolved `default` export is **cached** on the
+`LazyComponent` for subsequent navigations.
+
+```ts twoslash
+// @filename: User.ts
+export default {};
+// @filename: index.ts
+import { createCoreRouter, lazy } from "@isorouter/core";
+
+declare const Home: unknown;
+// ---cut---
+const router = createCoreRouter([
+  { path: "/", component: Home },
+  { path: "/users/:id", component: lazy(() => import("./User")) },
+] as const);
+```
+
+`lazy` is re-exported from every adapter too, so you import it from the same
+package as the rest of your router:
+
+```ts twoslash
+// @filename: User.ts
+export default {};
+// @filename: index.ts
+import { lazy } from "@isorouter/react"; // or /vue, /svelte
+// ---cut---
+const User = lazy(() => import("./User"));
+```
+
+## How it resolves
+
+- The import runs **once**, the first time the route matches.
+- While it's in flight, the snapshot is in `status: "navigating"` — adapters
+  render their `loading` slot/prop if there's no committed component yet.
+- The module's **`default` export** is used as the component.
+- If the import rejects, the navigation transitions to `status: "error"`.
+
+## Combine with guards
+
+Guards run before the lazy import is awaited for the committing leaf, so a
+blocked navigation **won't pay the download cost** of a chunk it never shows.
+
+```ts twoslash
+// @filename: Admin.ts
+export default {};
+// @filename: index.ts
+import { createCoreRouter, lazy } from "@isorouter/core";
+
+declare function isLoggedIn(): boolean;
+// ---cut---
+const router = createCoreRouter([
+  {
+    path: "/admin",
+    component: lazy(() => import("./Admin")),
+    beforeLoad: () => {
+      if (!isLoggedIn()) return "/login";
+    },
+  },
+] as const);
+```

--- a/docs/guide/links.md
+++ b/docs/guide/links.md
@@ -1,0 +1,59 @@
+# Links & active state
+
+## `<Link>`
+
+Every adapter ships a `<Link>` that renders a **plain `<a>`**. The Navigation
+API intercepts the click natively, so **modifier-clicks** (⌘/Ctrl/Shift),
+**`target="_blank"`** and **downloads** all behave correctly — for free, with
+no special-casing in isorouter.
+
+::: code-group
+
+```svelte [Svelte 5]
+<Link href="/dashboard" activeClass="active" exact>Dashboard</Link>
+```
+
+```tsx [React]
+<Link href="/dashboard" activeClassName="active" exact>
+  Dashboard
+</Link>
+```
+
+```ts [Vue 3]
+import { h } from "vue";
+import { Link } from "@isorouter/vue";
+
+h(Link, { href: "/dashboard", activeClass: "active", exact: true }, () =>
+  "Dashboard",
+);
+```
+
+:::
+
+### Props
+
+| Prop                                  | Description                                                            |
+| ------------------------------------- | --------------------------------------------------------------------- |
+| `href`                                | The target path.                                                      |
+| `activeClass` / `activeClassName` (React) | Class applied when the link is active (default `"active"`).        |
+| `exact`                               | When set, only an **exact** match counts as active.                   |
+
+When active, `<Link>` also sets `aria-current="page"`. All other attributes are
+forwarded to the underlying `<a>`. Note the prop name difference: React uses
+`activeClassName`, Svelte and Vue use `activeClass`.
+
+## Programmatic active checks
+
+The router exposes `isActive` for building your own active UI — it's also what
+`<Link>` uses internally:
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+const router = createCoreRouter([{ path: "/concerts/:city" }] as const);
+// ---cut---
+router.isActive("/concerts"); // true for "/concerts" AND "/concerts/kyiv"
+router.isActive("/concerts", { exact: true }); // true only for "/concerts"
+```
+
+By default `isActive(path)` is a **prefix** match (a parent link stays active
+while you're on its children); pass `{ exact: true }` to require an exact match.

--- a/docs/guide/nested-layouts.md
+++ b/docs/guide/nested-layouts.md
@@ -1,0 +1,81 @@
+# Nested layouts
+
+A route with `children` becomes a **layout**: its `component` renders, and you
+place an `<Outlet>` where the matched child should appear. The matched chain is
+rendered root → leaf, each layout pulling in the next via its `Outlet`.
+
+::: info Why layouts persist
+Layout component **identity is stable** across child navigations — navigating
+from `/dashboard/overview` to `/dashboard/settings` keeps the same
+`DashboardLayout` instance mounted (and its state, scroll, focus). Only the
+`<Outlet>` content swaps.
+:::
+
+## Example
+
+::: code-group
+
+```svelte [Svelte 5]
+<!-- DashboardLayout.svelte -->
+<script lang="ts">
+  import { Outlet } from "@isorouter/svelte";
+</script>
+
+<h1>Dashboard</h1>
+<Outlet />
+```
+
+```tsx [React]
+import { Outlet } from "@isorouter/react";
+
+function DashboardLayout() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <Outlet />
+    </div>
+  );
+}
+```
+
+```ts [Vue 3]
+import { defineComponent, h } from "vue";
+import { Outlet } from "@isorouter/vue";
+
+const DashboardLayout = defineComponent({
+  render: () => h("div", [h("h1", "Dashboard"), h(Outlet)]),
+});
+```
+
+:::
+
+Wire it up with `children`. An `index` route renders at the layout's own URL:
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+
+declare const DashboardLayout: unknown;
+declare const Overview: unknown;
+declare const Settings: unknown;
+// ---cut---
+const router = createCoreRouter([
+  {
+    path: "/dashboard",
+    component: DashboardLayout,
+    children: [
+      { index: true, component: Overview }, // /dashboard
+      { path: "settings", component: Settings }, // /dashboard/settings
+    ],
+  },
+] as const);
+```
+
+## Behaviour notes
+
+- `<Outlet>` renders the next component in the matched chain at the current
+  nesting depth, and **renders nothing** when there is no matching child.
+- A matched parent **with no matching child** still resolves on its own if the
+  path is fully consumed (e.g. `/dashboard` with no `index` route just renders
+  the layout with an empty `Outlet`).
+- Routes with no `component` are matched as **pass-through** layouts — they
+  group children under a path prefix without adding to `snapshot.components`.

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,0 +1,95 @@
+# Quick start
+
+A running router in a few lines. Pick your framework below — the route config
+shape is identical across all of them.
+
+## Core (any framework / none)
+
+```ts twoslash
+// @filename: User.ts
+export default {};
+// @filename: index.ts
+import { createCoreRouter, lazy } from "@isorouter/core";
+
+declare const Home: unknown;
+declare const Concerts: unknown;
+// ---cut---
+const router = createCoreRouter([
+  { path: "/", component: Home },
+  { path: "/concerts/:city", component: Concerts },
+  { path: "/users/:id", component: lazy(() => import("./User")) },
+] as const);
+
+router.subscribe((snapshot) => render(snapshot));
+router.start();
+
+function render(snapshot: unknown) {}
+```
+
+`createCoreRouter` is a thin wrapper around `new Router(routes, options)`. It
+returns an [external store](./introduction#why-this-shape) you can subscribe
+to; `router.start()` begins intercepting same-origin navigations.
+
+## With a framework
+
+::: code-group
+
+```svelte [Svelte 5]
+<!-- App.svelte -->
+<script lang="ts">
+  import { Router } from "@isorouter/svelte";
+  import type { AnySvelteRouter } from "@isorouter/svelte";
+
+  let { router }: { router: AnySvelteRouter } = $props();
+</script>
+
+<Router {router}>
+  {#snippet notFound()}<p>Not found</p>{/snippet}
+</Router>
+```
+
+```tsx [React]
+import { createRoot } from "react-dom/client";
+import { createRouter, Router } from "@isorouter/react";
+
+const router = createRouter([
+  { path: "/", component: Home },
+  { path: "about", component: About },
+] as const);
+
+createRoot(document.getElementById("root")!).render(
+  <Router router={router} notFound={<p>Not found</p>} />,
+);
+```
+
+```ts [Vue 3]
+import { createApp, defineComponent, h } from "vue";
+import { createRouter, RouterView } from "@isorouter/vue";
+
+const router = createRouter([
+  { path: "/", component: Home },
+  { path: "about", component: About },
+] as const);
+
+const App = defineComponent({
+  render: () =>
+    h(RouterView, { router }, { notFound: () => h("p", "Not found") }),
+});
+
+createApp(App).mount("#app");
+```
+
+:::
+
+`createRouter` is `createCoreRouter` with the component type fixed to your
+framework's component type. The root component (`<Router>` / `<RouterView>`)
+calls `router.start()` on mount and `router.stop()` on unmount, so you never
+manage the lifecycle by hand.
+
+## Where to go next
+
+- [Routing & matching](./routing) — params, splats, index routes, priority.
+- [Navigation guards](./guards) — `beforeLoad`, redirects, abort signals.
+- [Nested layouts](./nested-layouts) — `children` + `<Outlet>`.
+- Per-framework walkthroughs: [Svelte](../frameworks/svelte),
+  [React](../frameworks/react), [Vue](../frameworks/vue).

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -1,0 +1,121 @@
+# Routing & matching
+
+Routes are a plain array of config objects. The same shape is used by the core
+and every adapter.
+
+```ts twoslash
+import type { RouteConfig } from "@isorouter/core";
+// ---cut---
+interface Route {
+  path?: string;
+  index?: boolean;
+  component?: unknown; // a value or lazy(() => import(...))
+  beforeLoad?: unknown;
+  title?: string | ((ctx: unknown) => string);
+  children?: readonly Route[];
+}
+```
+
+## Path segments
+
+| Segment      | Example        | Matches                                         |
+| ------------ | -------------- | ----------------------------------------------- |
+| Static       | `"about"`      | exactly `/about`                                 |
+| Param        | `"users/:id"`  | `/users/42` → `params.id === "42"`              |
+| Splat (`*`)  | `"files/*"`    | `/files/a/b/c` → `params["*"] === "a/b/c"` (decoded) |
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+
+declare const Home: unknown;
+declare const User: unknown;
+declare const Files: unknown;
+// ---cut---
+const router = createCoreRouter([
+  { path: "/", component: Home },
+  { path: "/users/:id", component: User },
+  { path: "/files/*", component: Files },
+] as const);
+```
+
+## Matching priority
+
+When multiple routes could match a segment, isorouter resolves the conflict
+deterministically, **regardless of declaration order**:
+
+1. **Static** segments win over
+2. **params**, which win over
+3. **splats**.
+
+Ties within the same kind are broken by **source order**.
+
+## Index routes
+
+`index: true` matches when the parent's path is matched **exactly**, with no
+remaining segments. It's how you render content at a layout's own URL:
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+
+declare const DashboardLayout: unknown;
+declare const Overview: unknown;
+declare const Settings: unknown;
+// ---cut---
+const router = createCoreRouter([
+  {
+    path: "/dashboard",
+    component: DashboardLayout,
+    children: [
+      { index: true, component: Overview }, // /dashboard
+      { path: "settings", component: Settings }, // /dashboard/settings
+    ],
+  },
+] as const);
+```
+
+## Components are optional
+
+A route with no `component` is still **matched** — useful as a pass-through
+layout — but contributes nothing to `snapshot.components`. A matched parent
+with no matching child still resolves on its own if the path is fully consumed.
+
+## The snapshot
+
+Every commit produces an immutable `RouterSnapshot`:
+
+```ts twoslash
+interface RouterSnapshot<C> {
+  /** Matched chain's components, root → leaf (routes with no component removed). */
+  components: C[];
+  params: Record<string, string>;
+  url: URL;
+  status: "idle" | "navigating" | "not-found" | "error";
+  error: unknown;
+}
+```
+
+- `components` is the matched chain, root → leaf — render `components[0]` and
+  let each layout pull in the next with [`<Outlet>`](./nested-layouts).
+- `status` drives the loading / not-found / error UI in the adapters.
+
+See the [core API reference](../api/core) for the full surface.
+
+## Setting the document title
+
+A route can set `document.title` on commit via `title` — a string or a function
+of the guard context. The **deepest** route in the matched chain that defines a
+`title` wins:
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+
+declare const User: unknown;
+// ---cut---
+const router = createCoreRouter([
+  {
+    path: "/users/:id",
+    component: User,
+    title: (ctx) => `User ${ctx.params.id}`,
+  },
+] as const);
+```

--- a/docs/guide/type-safe-navigation.md
+++ b/docs/guide/type-safe-navigation.md
@@ -1,0 +1,95 @@
+# Type-safe navigation
+
+Declaring routes `as const` gives the router **compile-time path templates**.
+`navigate` (and the adapters' `useNavigate`) then only accept paths your routes
+actually define — typos and stale links become **type errors**, not runtime
+404s.
+
+::: tip Hover the code
+The examples on this page are powered by Twoslash — hover any identifier to see
+its inferred type, exactly as your editor would.
+:::
+
+## Known paths only
+
+```ts twoslash
+// @errors: 2345
+import { createCoreRouter } from "@isorouter/core";
+
+const router = createCoreRouter([
+  { path: "/" },
+  { path: "/concerts/:city" },
+  { path: "/users/:id" },
+] as const);
+
+router.navigate("/concerts/kyiv"); // ok
+router.navigate("/concerts/kyiv?from=search"); // ok — optional ?query
+router.navigate("/users/42#bio"); // ok — optional #hash
+router.navigate("/no-such-route"); // type error
+```
+
+The param segment `"/concerts/:city"` becomes the template
+`` `/concerts/${string}` ``, so any city value type-checks while the **shape**
+is enforced. An optional `?query` and/or `#hash` may be appended to any known
+path.
+
+## Extracting param types
+
+`ExtractParams` resolves a path template to its params object — handy for typing
+params you read elsewhere:
+
+```ts twoslash
+import type { ExtractParams } from "@isorouter/core";
+
+type Params = ExtractParams<"/concerts/:city">;
+//   ^?
+```
+
+## With the adapters
+
+`useNavigate()` carries the same path types through. Declare routes `as const`,
+and the returned function rejects unknown paths:
+
+::: code-group
+
+```tsx [React]
+import { useNavigate } from "@isorouter/react";
+
+function Search() {
+  const navigate = useNavigate();
+  // navigate("/concerts/kyiv") ✓   navigate("/nope") ✗ (type error)
+  return <button onClick={() => navigate("/concerts/kyiv")}>Go</button>;
+}
+```
+
+```ts [Vue 3]
+import { useNavigate } from "@isorouter/vue";
+
+const navigate = useNavigate();
+// navigate("/concerts/kyiv") ✓   navigate("/nope") ✗ (type error)
+navigate("/concerts/kyiv");
+```
+
+```svelte [Svelte 5]
+<script lang="ts">
+  import { getRouter } from "@isorouter/svelte";
+  const router = getRouter();
+  // router.navigate("/concerts/kyiv") ✓   router.navigate("/nope") ✗
+</script>
+```
+
+:::
+
+## Navigation options
+
+`navigate` takes an optional second argument:
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+const router = createCoreRouter([{ path: "/concerts/:city" }] as const);
+// ---cut---
+router.navigate("/concerts/kyiv", {
+  replace: true, // replace the current history entry instead of pushing
+  state: { from: "search" }, // attach state to the navigation entry
+});
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,44 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  # The "isorouter" name is rendered as the two-tone <Wordmark> via the
+  # home-hero-info-before slot (see .vitepress/theme/index.ts).
+  text: "One router. Any framework. The platform underneath."
+  tagline: A lightweight SPA router built on the browser Navigation API — a zero-dependency TypeScript core with thin Svelte 5, React and Vue 3 adapters.
+  image:
+    light: /logo-light.svg
+    dark: /logo.svg
+    alt: isorouter
+  actions:
+    - theme: brand
+      text: Get started
+      link: /guide/introduction
+    - theme: alt
+      text: Quick start
+      link: /guide/quick-start
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/pidkhvatylin-my/isorouter
+
+features:
+  - icon: 🧩
+    title: Framework-agnostic core
+    details: Matching, guards, lazy-loading and the async-commit state machine live in pure TypeScript with zero runtime dependencies. Use it directly, or through a 1-file adapter.
+  - icon: 🌐
+    title: Built on the Navigation API
+    details: Link clicks are intercepted natively — modifier-clicks, target="_blank" and downloads behave correctly for free. No History API guesswork.
+  - icon: 🪶
+    title: Tiny
+    details: The core is ~4 KB minified (1.8 KB gzipped) with zero runtime dependencies and sideEffects&nbsp;false for full tree-shaking. Each adapter adds only ~0.5 KB gzipped on top.
+  - icon: 🔒
+    title: Type-safe navigation
+    details: Declare routes "as const" and navigate() only accepts known paths at compile time — "/users/:id" becomes `/users/${string}`, with optional ?query / #hash.
+  - icon: ⚛️
+    title: Svelte 5, React & Vue 3
+    details: One immutable-snapshot external store, three native bridges — createSubscriber, useSyncExternalStore and shallowRef. Correct, tear-free updates everywhere.
+  - icon: 🛡️
+    title: Guards, lazy & nested layouts
+    details: beforeLoad guards run root→leaf with an abort signal, redirects and blocking. Layout components persist across child navigations via stable identity.
+---

--- a/docs/public/logo-light.svg
+++ b/docs/public/logo-light.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="isorouter">
+  
+  <polygon points="15.4,30 50,50 50,90 15.4,70" fill="#0C1D35"></polygon>
+  <polygon points="84.6,30 84.6,70 50,90 50,50" fill="#173462"></polygon>
+  <polygon points="50,10 84.6,30 50,50 15.4,30" fill="#7B8EFB"></polygon>
+  <polyline points="50,10 84.6,30 50,50 15.4,30 50,10" fill="none" stroke="#4A5CE8" stroke-width="1.3" stroke-linejoin="round"></polyline>
+  <polyline points="84.6,30 84.6,70 50,90 15.4,70 15.4,30" fill="none" stroke="rgba(0,0,0,0.1)" stroke-width="0.8"></polyline>
+  <line x1="50" y1="90" x2="50" y2="50" stroke="rgba(0,0,0,0.1)" stroke-width="0.8"></line>
+  <circle cx="50" cy="50" r="4.5" fill="white"></circle>
+</svg>

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="isorouter">
+  
+  <polygon points="15.4,30 50,50 50,90 15.4,70" fill="#0C1D35"></polygon>
+  <polygon points="84.6,30 84.6,70 50,90 50,50" fill="#173462"></polygon>
+  <polygon points="50,10 84.6,30 50,50 15.4,30" fill="#7B8EFB"></polygon>
+  <polyline points="50,10 84.6,30 50,50 15.4,30 50,10" fill="none" stroke="#9EABFC" stroke-width="1.3" stroke-linejoin="round"></polyline>
+  <polyline points="84.6,30 84.6,70 50,90 15.4,70 15.4,30" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.8"></polyline>
+  <line x1="50" y1="90" x2="50" y2="50" stroke="rgba(255,255,255,0.1)" stroke-width="0.8"></line>
+  <circle cx="50" cy="50" r="4.5" fill="#BEC7FE"></circle>
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,12 @@
       ],
       "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",
-        "@changesets/cli": "^2.31.0"
+        "@changesets/cli": "^2.31.0",
+        "@shikijs/vitepress-twoslash": "^4.2.0",
+        "vitepress": "^1.6.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -19,6 +24,264 @@
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.0.tgz",
+      "integrity": "sha512-kGvHfBa9oQCvZh0YXeguSToBD9GNJ+gzUZQ9KPTg+KSsM36obYcsKPoX0NnlJtPflHXu7RkMaIi44xs9meR6Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.0.tgz",
+      "integrity": "sha512-Zt2GjIm7vsaf7K23tk5JmtcVNc38G9p0C2L2Lrm06miyLE/NL2etHtHInvuLc1DjxTp7Y2nId4X/tzwo372K8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.0.tgz",
+      "integrity": "sha512-7BueMuWYg/KBA2EX9zsQ+3OAleEyrJcB+SV5Al/9pLjMQq5mXB/8M5HaUPqZwN812g5kLzj9j43VThlZgWq0hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.0.tgz",
+      "integrity": "sha512-pJZIyhvUrs+B7c5Lw0iP5yP/NsqJMda7pKRYbfG4KtfGIVSMcAalZhdqL5UX8Z9DOC4KxO9tKV5RDeVjZU0VfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.0.tgz",
+      "integrity": "sha512-RydkKDhx0GWTYuw0ndTXHGM8hD8hgwftKE65FfnJZb5bPc9CevOqv3qNPUQiviAwkqT9hQNH31uDGeV3yZkgfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.0.tgz",
+      "integrity": "sha512-XiS7gdFq/COWiwdWXZ8+RHuewfEo03TkGESk44zU8zTc/Z6R8fm4DNmV52swJKkeB2N9iC7NKpgpM22OOkcgTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.0.tgz",
+      "integrity": "sha512-LBEJ/q+hn1nJ0aYg5IcWgLNCPjWHTahWmpHNx1qUZMho+9CyWM6LaEnhac45UHjQm/j0m374HP685VrpL133lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.0.tgz",
+      "integrity": "sha512-2/9jUXKH4IcdU5qxH6cbDH46ZBe46G7xr+MrcHwgEXZcUfdAvUgLSH53MAWuMgxvw0G5yoqiWMifHc62Os0fiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.0.tgz",
+      "integrity": "sha512-80tKsQgxXWo+jK0v4YGCHqyTEXawhAKYyr3kOdN51ElfRqUFjZNPVhZk6vRiqSqXfvrH85ytacT3cbJR6+qolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.0.tgz",
+      "integrity": "sha512-4UjmAL8ywGW4rCfK6Qmgw3wIjbrO2wl2s4Eq56JTiN40L2t0XTv0HZkYAmr6nfeiXO0he/2crvZRX6SATSepag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.0.tgz",
+      "integrity": "sha512-LMpJPtIkfDsHIx5Ga+baNr22ntYbY+e2wT7MSIc/FjAnu9wnBFhx1H/GfhmP/c5/IvbThDX+3ilxPRjSfCI8aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.0.tgz",
+      "integrity": "sha512-tDymJ7nFOAoUuecma3usK6o94dp8m4HYFDGh4ByYQXWkv14cpmDn+nWdylmcZO0Qvco107vqDo4+Anksnl8w1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.0.tgz",
+      "integrity": "sha512-6IDSB5o5dkDPQ4LdOW0Yuw/qy5MdWlO2xDHgPVZgW4YDjbxvnX5PAiV7/WWZdWyVObScZZnnHpPbiqfYs/zBLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.0.tgz",
+      "integrity": "sha512-Yyyne4l//vDSdg4MhYJkaVne+KEPi833eCj3/T/87ernTwrvP6j9biXXZELsN8sLI/f2ndV/vugDIy2jdJQB6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -818,6 +1081,57 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
@@ -998,6 +1312,33 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.1.tgz",
+      "integrity": "sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.1.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1063,6 +1404,23 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.86",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.86.tgz",
+      "integrity": "sha512-t3jck5qPQuK1qy+bRn9eCoDQhIB7XSazKz1Fjp8hcan3XOAsTI5Mq/s3F0ekOKSvMQqkVORYK6ns6o6T9f5EMA==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
@@ -1698,6 +2056,618 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.2.0",
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.2.0.tgz",
+      "integrity": "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.2.0.tgz",
+      "integrity": "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.2.0.tgz",
+      "integrity": "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.2.0.tgz",
+      "integrity": "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.2.0.tgz",
+      "integrity": "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/transformers/node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/@shikijs/twoslash": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/twoslash/-/twoslash-4.2.0.tgz",
+      "integrity": "sha512-PG/F0tMyt4zAvHVBL7Ehtk/ZpI2Rq3PwaXRYJaOO41eIK/iV9GOO/20jZhQkScOdcP6aFwHC2/x/GxmeR4tMlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.2.0",
+        "@shikijs/types": "4.2.0",
+        "twoslash": "^0.3.8"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.2.0.tgz",
+      "integrity": "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vitepress-twoslash": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/vitepress-twoslash/-/vitepress-twoslash-4.2.0.tgz",
+      "integrity": "sha512-xji8w8GLho9XuBi+1chJg3K4jRiM9dSq21tL44HrxP2mkRqTadUOcCT+cW2fbjcLE6Zq6AkRizDWXD7yFjyVTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/twoslash": "4.2.0",
+        "floating-vue": "^5.2.2",
+        "lz-string": "^1.5.0",
+        "magic-string": "^0.30.21",
+        "markdown-it": "^14.2.0",
+        "mdast-util-from-markdown": "^2.0.3",
+        "mdast-util-gfm": "^3.1.0",
+        "mdast-util-to-hast": "^13.2.1",
+        "ohash": "^2.0.11",
+        "shiki": "4.2.0",
+        "twoslash": "^0.3.8",
+        "twoslash-vue": "^0.3.8",
+        "vue": "^3.5.35"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1936,6 +2906,16 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1957,10 +2937,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2006,6 +3038,20 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2239,6 +3285,26 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript/vfs": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.4.tgz",
+      "integrity": "sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@virtualstate/composite-key": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@virtualstate/composite-key/-/composite-key-1.0.0.tgz",
@@ -2436,6 +3502,23 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.38",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
@@ -2488,6 +3571,58 @@
       "dependencies": {
         "@vue/compiler-dom": "3.5.38",
         "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.5.tgz",
+      "integrity": "sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.0",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -2566,6 +3701,112 @@
         }
       }
     },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/abbrev": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
@@ -2615,6 +3856,39 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.0.tgz",
+      "integrity": "sha512-af+rI+tUVeS9KWHPAZQHIHPOIC3StPRR6IwQu2nz1aQoTL6Gs5Ty3KsHCgbXMHOpoh9QqSjq8F3KJ8xmaCZSBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.21.0",
+        "@algolia/client-abtesting": "5.55.0",
+        "@algolia/client-analytics": "5.55.0",
+        "@algolia/client-common": "5.55.0",
+        "@algolia/client-insights": "5.55.0",
+        "@algolia/client-personalization": "5.55.0",
+        "@algolia/client-query-suggestions": "5.55.0",
+        "@algolia/client-search": "5.55.0",
+        "@algolia/ingestion": "1.55.0",
+        "@algolia/monitoring": "1.55.0",
+        "@algolia/recommend": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -2764,6 +4038,16 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
@@ -2845,6 +4129,17 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2853,6 +4148,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chardet": {
@@ -2908,6 +4236,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -2935,6 +4274,22 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3038,6 +4393,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dedent-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
@@ -3098,6 +4467,20 @@
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -3199,6 +4582,13 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3703,6 +5093,36 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/floating-vue": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/floating-vue/-/floating-vue-5.2.2.tgz",
+      "integrity": "sha512-afW+h2CFafo+7Y9Lvw/xsqjaQlKLdJV7h1fCHfcYQ1C4SVMlu7OAekqWgu5d4SgvkBVU0pVpLlVsrSTBURFRkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "~1.1.1",
+        "vue-resize": "^2.0.0-alpha.1"
+      },
+      "peerDependencies": {
+        "@nuxt/kit": "^3.2.0",
+        "vue": "^3.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@nuxt/kit": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -3879,6 +5299,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -3895,6 +5353,13 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -3915,6 +5380,17 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/human-id": {
       "version": "4.2.0",
@@ -4051,6 +5527,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-windows": {
@@ -4616,6 +6105,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
@@ -4645,6 +6154,17 @@
       "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -4724,12 +6244,313 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4740,6 +6561,469 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -4804,6 +7088,20 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -4818,6 +7116,13 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4931,6 +7236,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/optionator": {
@@ -5063,6 +7394,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5121,6 +7459,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5338,6 +7683,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5393,6 +7749,17 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -5426,6 +7793,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5572,6 +7949,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5602,6 +8006,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.1.1",
@@ -5635,6 +8046,51 @@
         "@rolldown/binding-wasm32-wasi": "1.1.1",
         "@rolldown/binding-win32-arm64-msvc": "1.1.1",
         "@rolldown/binding-win32-x64-msvc": "1.1.1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -5711,6 +8167,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/semver": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
@@ -5745,6 +8209,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
+      "integrity": "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.2.0",
+        "@shikijs/engine-javascript": "4.2.0",
+        "@shikijs/engine-oniguruma": "4.2.0",
+        "@shikijs/langs": "4.2.0",
+        "@shikijs/themes": "4.2.0",
+        "@shikijs/types": "4.2.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/siginfo": {
@@ -5787,6 +8271,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spawndamnit": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
@@ -5796,6 +8291,16 @@
       "dependencies": {
         "cross-spawn": "^7.0.5",
         "signal-exit": "^4.0.1"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -5873,6 +8378,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -5937,6 +8457,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/supports-color": {
@@ -6136,6 +8669,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -6252,6 +8792,17 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6272,6 +8823,45 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/twoslash": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/twoslash/-/twoslash-0.3.8.tgz",
+      "integrity": "sha512-OeDz0kDl8sqPUN3nr7gqcvOs70f5lZsdhKYTX3/SgB9OvdadzzoYJI/4SBXhXV1HG8E9fLc+e17itoRYTxmoig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript/vfs": "^1.6.4",
+        "twoslash-protocol": "0.3.8"
+      },
+      "peerDependencies": {
+        "typescript": "^5.5.0 || ^6.0.0"
+      }
+    },
+    "node_modules/twoslash-protocol": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/twoslash-protocol/-/twoslash-protocol-0.3.8.tgz",
+      "integrity": "sha512-HmvAHoiEviK8LqvAQyc9/irkdvwTUiR1fHmNwH/0gq8EHxyBt4PWVPixjEXg6wJu1u6yBrILEWXGK9Kw58/8yQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/twoslash-vue": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/twoslash-vue/-/twoslash-vue-0.3.8.tgz",
+      "integrity": "sha512-5HZAnkQ1R6NXqW9mqsHx4aHVWPb5gb4gfEKiaNczi3q6U7vDZeVv9eONRuPs4qdCd5OJSAIpHeXxIDZmjr0Jww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/language-core": "^3.2.6",
+        "twoslash": "0.3.8",
+        "twoslash-protocol": "0.3.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "typescript": "^5.5.0 || ^6.0.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6324,6 +8914,13 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
@@ -6340,6 +8937,79 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -6398,6 +9068,36 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.16",
@@ -6850,6 +9550,650 @@
         }
       }
     },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitepress/node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/vitepress/node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/vitepress/node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/vitepress/node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/vitepress/node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/vitepress/node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/vitepress/node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/vitepress/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitepress/node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/vitepress/node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/vitepress/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
@@ -6968,6 +10312,16 @@
       "integrity": "sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vue-resize": {
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -7228,6 +10582,17 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "packages/core": {
       "name": "@isorouter/core",
       "version": "1.0.0",
@@ -7248,6 +10613,9 @@
         "typescript-eslint": "^8.61.0",
         "vite": "^8.0.0",
         "vitest": "^4.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "packages/react": {
@@ -7282,6 +10650,9 @@
         "typescript-eslint": "^8.61.0",
         "vite": "^8.0.0",
         "vitest": "^4.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
         "react": ">=18"
@@ -7319,6 +10690,9 @@
         "vite": "^8.0.0",
         "vitest": "^4.1.0"
       },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
       "peerDependencies": {
         "svelte": "^5.7.0"
       }
@@ -7334,6 +10708,9 @@
         "prettier": "^3.8.4",
         "typescript": "^6.0.0",
         "typescript-eslint": "^8.61.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "packages/vue": {
@@ -7361,6 +10738,9 @@
         "vite": "^8.0.0",
         "vitest": "^4.1.0",
         "vue": "^3.4.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
         "vue": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -13,10 +13,15 @@
     "check": "npm run check --workspaces --if-present",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "npm run build && changeset publish"
+    "release": "npm run build && changeset publish",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
-    "@changesets/cli": "^2.31.0"
+    "@changesets/cli": "^2.31.0",
+    "@shikijs/vitepress-twoslash": "^4.2.0",
+    "vitepress": "^1.6.4"
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,7 @@
 # @isorouter/core
 
 [![npm version](https://img.shields.io/npm/v/%40isorouter%2Fcore.svg)](https://www.npmjs.com/package/@isorouter/core)
+[![minzip](https://img.shields.io/bundlephobia/minzip/%40isorouter%2Fcore?label=gzip)](https://bundlephobia.com/package/@isorouter/core)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 A lightweight, **framework-agnostic SPA router built on the browser
@@ -15,11 +16,12 @@ directly, or through a thin adapter:
 
 ## Size
 
-A single unminified ESM file, **8.3 KB (3.1 KB gzipped)**, with **zero
-runtime dependencies** and `"sideEffects": false` for full tree-shaking —
-your bundler's own minification shrinks it further. The published npm
-package (incl. type declarations, README and LICENSE) is ~9 KB packed / ~25
-KB unpacked across 9 files.
+A single ESM file — **~4 KB minified, 1.8 KB gzipped**
+([Bundlephobia](https://bundlephobia.com/package/@isorouter/core)) — with
+**zero runtime dependencies** and `"sideEffects": false` for full
+tree-shaking. The unminified source is 8.3 KB; the published npm package
+(incl. type declarations, README and LICENSE) is ~9 KB packed / ~25 KB
+unpacked across 9 files.
 
 ## Install
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,7 @@
 # @isorouter/react
 
 [![npm version](https://img.shields.io/npm/v/%40isorouter%2Freact.svg)](https://www.npmjs.com/package/@isorouter/react)
+[![minzip](https://img.shields.io/bundlephobia/minzip/%40isorouter%2Freact?label=gzip)](https://bundlephobia.com/package/@isorouter/react)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 React bindings for

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,6 +1,7 @@
 # @isorouter/svelte
 
 [![npm version](https://img.shields.io/npm/v/%40isorouter%2Fsvelte.svg)](https://www.npmjs.com/package/@isorouter/svelte)
+[![minzip](https://img.shields.io/badge/gzip-~2.3%20KB-blue.svg)](https://www.npmjs.com/package/@isorouter/svelte)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 Svelte 5 bindings for

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,6 +1,7 @@
 # @isorouter/vue
 
 [![npm version](https://img.shields.io/npm/v/%40isorouter%2Fvue.svg)](https://www.npmjs.com/package/@isorouter/vue)
+[![minzip](https://img.shields.io/bundlephobia/minzip/%40isorouter%2Fvue?label=gzip)](https://bundlephobia.com/package/@isorouter/vue)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 Vue 3 bindings for

--- a/public/logo-light.svg
+++ b/public/logo-light.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="isorouter">
+  
+  <polygon points="15.4,30 50,50 50,90 15.4,70" fill="#0C1D35"></polygon>
+  <polygon points="84.6,30 84.6,70 50,90 50,50" fill="#173462"></polygon>
+  <polygon points="50,10 84.6,30 50,50 15.4,30" fill="#7B8EFB"></polygon>
+  <polyline points="50,10 84.6,30 50,50 15.4,30 50,10" fill="none" stroke="#4A5CE8" stroke-width="1.3" stroke-linejoin="round"></polyline>
+  <polyline points="84.6,30 84.6,70 50,90 15.4,70 15.4,30" fill="none" stroke="rgba(0,0,0,0.1)" stroke-width="0.8"></polyline>
+  <line x1="50" y1="90" x2="50" y2="50" stroke="rgba(0,0,0,0.1)" stroke-width="0.8"></line>
+  <circle cx="50" cy="50" r="4.5" fill="white"></circle>
+</svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="isorouter">
+  
+  <polygon points="15.4,30 50,50 50,90 15.4,70" fill="#0C1D35"></polygon>
+  <polygon points="84.6,30 84.6,70 50,90 50,50" fill="#173462"></polygon>
+  <polygon points="50,10 84.6,30 50,50 15.4,30" fill="#7B8EFB"></polygon>
+  <polyline points="50,10 84.6,30 50,50 15.4,30 50,10" fill="none" stroke="#9EABFC" stroke-width="1.3" stroke-linejoin="round"></polyline>
+  <polyline points="84.6,30 84.6,70 50,90 15.4,70 15.4,30" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.8"></polyline>
+  <line x1="50" y1="90" x2="50" y2="50" stroke="rgba(255,255,255,0.1)" stroke-width="0.8"></line>
+  <circle cx="50" cy="50" r="4.5" fill="#BEC7FE"></circle>
+</svg>

--- a/public/wordmark-light.svg
+++ b/public/wordmark-light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="260" viewBox="0 0 300 72" role="img" aria-label="isorouter">
+  <text x="150" y="52" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="56" font-weight="800" letter-spacing="-1.5"><tspan fill="#4A5CE8">iso</tspan><tspan fill="#0C1D35">router</tspan></text>
+</svg>

--- a/public/wordmark.svg
+++ b/public/wordmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="260" viewBox="0 0 300 72" role="img" aria-label="isorouter">
+  <text x="150" y="52" text-anchor="middle" font-family="Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="56" font-weight="800" letter-spacing="-1.5"><tspan fill="#9EABFC">iso</tspan><tspan fill="#FFFFFF">router</tspan></text>
+</svg>


### PR DESCRIPTION
## Summary

Adds a full VitePress documentation site for isorouter 1.0.0, deployed to GitHub
Pages, plus brand assets (logo + two-tone wordmark) and accurate bundle-size
reporting across the READMes.

## What's included

### 📚 Documentation site (VitePress + Twoslash)
- New `docs/` workspace driven by VitePress 1.6, with the brand palette, local
  search, `lastUpdated`, clean URLs and OG/Twitter meta.
- **Twoslash** type hovers on the TypeScript examples — code samples are
  type-checked at build time against the actual built packages (lazy `import()`
  examples use virtual `// @filename` modules; the type-safe-navigation page
  asserts the expected `2345` error).
- Content (18 pages), sourced from the package READMEs and verified against each
  `src/index.ts`:
  - **Guide:** introduction · installation · quick-start · routing · guards ·
    lazy-loading · nested-layouts · links · type-safe-navigation · browser-support
  - **Frameworks:** Svelte 5 · React · Vue 3
  - **API reference:** core · svelte · react · vue
  - Home page with hero + feature grid; shared examples shown via `code-group`
    tabs across the three frameworks.

### 🚀 Deployment
- New `.github/workflows/docs.yml`: official Pages pipeline
  (`configure-pages` → `upload-pages-artifact` → `deploy-pages`), triggered on
  pushes to `master` touching `docs/**`, `packages/*/README.md` or the workflow
  itself, plus `workflow_dispatch`.
- Builds the packages before the docs (Twoslash needs the built types). The
  existing `ci.yml` / changesets release flow is untouched.
- Root scripts added: `docs:dev`, `docs:build`, `docs:preview`.

### 🎨 Branding
- Logo wired into the nav bar (light/dark), the home hero and the favicon.
- Two-tone **`isorouter`** wordmark (`iso` in the brand accent, `router` in the
  foreground) implemented as a `<Wordmark>` component injected via theme slots;
  brand palette derived from the logo drives links, buttons and active state.
- README: centered logo + SVG wordmark via `<picture>` (GitHub strips inline
  text colors, so the wordmark ships as light/dark SVGs).

### 📦 Bundle size accuracy
- Replaced the overstated "8.3 KB / 3.1 KB" figure (that was the *unminified*
  size) with real Bundlephobia numbers on the site and core README:
  core ~4.0 KB min / ~1.8 KB gzip, react/vue ~2.3 KB gzip.
- Added Bundlephobia minzip badges to the root README and core/react/vue
  package READMEs; Svelte gets a static `~2.3 KB` badge (Bundlephobia can't
  build `.svelte` exports).

## Reviewer notes
- `docs/.vitepress/dist` and `cache` are gitignored.
- The logo lives in both `public/` (README) and `docs/public/` (site) — keep the
  two in sync if the artwork changes.

## ⚠️ One-time manual step
After merge, set **Settings → Pages → Build and deployment → Source = GitHub
Actions** so the workflow can publish to
`https://pidkhvatylin-my.github.io/isorouter/`.

## Test plan
- [x] `npm run docs:build` passes (all 18 pages render, Twoslash type-checks clean)
- [ ] Pages source set to "GitHub Actions"; first deploy succeeds
- [ ] Logo + wordmark render correctly in light and dark themes