### PR TITLE
fix(core): bulletproof the route matcher for 1.0.1

### DIFF
--- a/.changeset/matcher-safe-decode.md
+++ b/.changeset/matcher-safe-decode.md
@@ -1,0 +1,9 @@
+---
+"@isorouter/core": patch
+---
+
+Guard the route matcher against malformed percent-encoding. A pathname segment
+containing an invalid escape — a lone `%`, bad hex digits, or invalid UTF-8 byte
+sequences — previously threw `URIError` from `decodeURIComponent` mid-match and
+aborted the navigation. Such segments now fall back to their raw value, so
+matching always resolves to a route or `null` and never crashes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4950,6 +4950,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7809,6 +7832,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -10606,6 +10646,7 @@
         "@vitest/coverage-v8": "^4.1.0",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
+        "fast-check": "^4.8.0",
         "prettier": "^3.8.4",
         "publint": "^0.3.0",
         "rolldown": "^1.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,7 @@
     "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
+    "fast-check": "^4.8.0",
     "prettier": "^3.8.4",
     "publint": "^0.3.0",
     "rolldown": "^1.1.0",

--- a/packages/core/src/matcher.ts
+++ b/packages/core/src/matcher.ts
@@ -1,4 +1,17 @@
+/**
+ * Route matching algorithm for @isorouter/core.
+ *
+ * Resolves a pathname against a `RouteConfig` tree and returns the first matched
+ * chain (root → leaf) together with the merged path params, or `null` when
+ * nothing matches.
+ *
+ * Specificity order (high → low): index > static segment > `:param` > `*` splat.
+ * Equal-specificity siblings fall back to declaration order (first wins).
+ */
+
 import type { RouteConfig, RouteMatch } from "./types";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
 
 const PARAM_PREFIX = ":";
 const SPLAT = "*";
@@ -23,6 +36,8 @@ const SEGMENT_SCORE = {
  */
 const INDEX_SCORE = Number.MAX_SAFE_INTEGER;
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
 function segments(path: string): string[] {
   return path.split("/").filter(Boolean);
 }
@@ -31,18 +46,39 @@ function isParam(segment: string): boolean {
   return segment.startsWith(PARAM_PREFIX);
 }
 
-/** Higher score = more specific. Ties are broken by source order (stable sort). */
+/**
+ * Decode a path segment, falling back to the raw value when it contains
+ * malformed percent-encoding. The Navigation API hands us `url.pathname`
+ * verbatim and it is NOT guaranteed to be well-formed (a lone `%`, bad hex, or
+ * invalid UTF-8 byte sequences all survive URL parsing), so an unguarded
+ * `decodeURIComponent` would throw `URIError` mid-match and crash navigation.
+ */
+function safeDecode(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+/** Higher score = more specific. Equal scores are broken by declaration order (see `matchLevel`). */
 function specificity(route: RouteConfig): number {
   if (route.index) return INDEX_SCORE;
+
   let score = 0;
+
   for (const segment of segments(route.path ?? "")) {
     if (segment === SPLAT) score += SEGMENT_SCORE.splat;
     else if (isParam(segment)) score += SEGMENT_SCORE.param;
     else score += SEGMENT_SCORE.static;
   }
+
   return score;
 }
 
+// ─── Core Algorithm ───────────────────────────────────────────────────────────
+
+/** Outcome of matching a single route's own segments against the head of a path. */
 interface SegmentMatch {
   params: Record<string, string>;
   /** Path segments left for child routes to consume; empty when a splat ate the rest. */
@@ -62,14 +98,17 @@ function matchSegments(
     const routeSeg = routeSegs[i]!;
 
     if (routeSeg === SPLAT) {
-      params[SPLAT] = pathSegs.slice(i).map(decodeURIComponent).join("/");
+      params[SPLAT] = pathSegs.slice(i).map(safeDecode).join("/");
+
       return { params, rest: [], splat: true };
     }
 
     const pathSeg = pathSegs[i];
+
     if (pathSeg === undefined) return null; // route is longer than the path
 
-    const decoded = decodeURIComponent(pathSeg);
+    const decoded = safeDecode(pathSeg);
+
     if (isParam(routeSeg)) params[routeSeg.slice(1)] = decoded;
     else if (routeSeg !== decoded) return null; // static segment mismatch
   }
@@ -77,6 +116,11 @@ function matchSegments(
   return { params, rest: pathSegs.slice(routeSegs.length), splat: false };
 }
 
+/**
+ * Try to match `pathSegs` against one level of the route tree, recursing into
+ * children when a layout route partially consumes the path. Siblings are tried
+ * most-specific-first (stable by declaration order); the first full match wins.
+ */
 function matchLevel<C>(
   routes: readonly RouteConfig<C>[],
   pathSegs: string[],
@@ -88,20 +132,25 @@ function matchLevel<C>(
     if (route.index) {
       if (pathSegs.length === 0)
         return { chain: [route], params: parentParams };
+
       continue;
     }
 
     const matched = matchSegments(segments(route.path ?? ""), pathSegs);
+
     if (!matched) continue;
 
     const params = { ...parentParams, ...matched.params };
 
     if (route.children) {
       const child = matchLevel(route.children, matched.rest, params);
+
       if (child)
         return { chain: [route, ...child.chain], params: child.params };
       // A layout route still matches its own URL even with no matching child.
+
       if (matched.rest.length === 0) return { chain: [route], params };
+
       continue;
     }
 
@@ -113,9 +162,16 @@ function matchLevel<C>(
   return null;
 }
 
+// ─── Public API ───────────────────────────────────────────────────────────────
+
 /**
- * Resolve a pathname against a route config, returning the matched route chain
- * (root → leaf) and the merged path params, or `null` when nothing matches.
+ * Resolve a pathname against a route config tree.
+ *
+ * @param routes - The root-level route config (as passed to `createCoreRouter`).
+ * @param pathname - A raw `url.pathname` string. Malformed percent-encoding is
+ *   tolerated; callers do not need to sanitise it first.
+ * @returns The matched route chain (root → leaf) and merged path params, or
+ *   `null` when no route claims the pathname.
  */
 export function matchRoutes<C>(
   routes: readonly RouteConfig<C>[],

--- a/packages/core/test/unit/matcher/basic.test.ts
+++ b/packages/core/test/unit/matcher/basic.test.ts
@@ -1,6 +1,15 @@
+/**
+ * Baseline specification for `matchRoutes`.
+ *
+ * Covers the canonical behaviour of every feature in isolation: static paths,
+ * specificity ranking, dynamic params, splat capture, index routes, nested
+ * layouts, path normalisation, and pathless wrappers. Each case is the minimum
+ * reproducer for its contract.
+ */
+
 import { describe, expect, it } from "vitest";
-import { matchRoutes } from "../../src/matcher";
-import type { RouteConfig } from "../../src/types";
+import { matchRoutes } from "../../../src/matcher";
+import type { RouteConfig } from "../../../src/types";
 
 describe("matchRoutes", () => {
   it("matches a static route", () => {

--- a/packages/core/test/unit/matcher/edge-cases.test.ts
+++ b/packages/core/test/unit/matcher/edge-cases.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Edge cases ported from the public path-matching suites of:
+ *   - remix-run/react-router  (packages/react-router/__tests__/matchPath-test.tsx)
+ *   - TanStack/router         (packages/router-core/tests/match-by-path.test.ts, path.test.ts)
+ *
+ * Their patterns are translated to this matcher's API:
+ *   `$id`/`:id` -> `:id`,  `$`/`{$}` splat -> `*`,  index route -> `{ index: true }`.
+ *
+ * Where our semantics deliberately diverge from those routers it is called out
+ * inline — chiefly: (a) matching is CASE-SENSITIVE (react-router is not by
+ * default), and (b) trailing/duplicate slashes are normalized away on BOTH the
+ * route and the pathname (TanStack is trailing-slash sensitive by default).
+ */
+
+import { describe, expect, it } from "vitest";
+import { matchRoutes } from "../../../src/matcher";
+import type { RouteConfig } from "../../../src/types";
+
+const r = (...routes: RouteConfig<string>[]) => routes;
+const chain = (m: ReturnType<typeof matchRoutes<string>>) =>
+  m?.chain.map((route) => route.component);
+
+describe("static matching", () => {
+  it("matches exact static paths and rejects mismatches", () => {
+    const routes = r({ path: "a/b", component: "ab" });
+    expect(chain(matchRoutes(routes, "/a/b"))).toEqual(["ab"]);
+    expect(matchRoutes(routes, "/b")).toBeNull();
+    expect(matchRoutes(routes, "/a")).toBeNull();
+  });
+
+  it("matches the empty pathname and the bare root against '/'", () => {
+    const routes = r({ path: "/", component: "home" });
+    expect(chain(matchRoutes(routes, ""))).toEqual(["home"]);
+    expect(chain(matchRoutes(routes, "/"))).toEqual(["home"]);
+  });
+
+  // react-router: "/usersblah" must NOT match "/users" — a static segment is
+  // matched whole, never as a prefix of a longer segment.
+  it("does not match a static segment as a prefix of a longer segment", () => {
+    const routes = r({ path: "users", component: "users" });
+    expect(matchRoutes(routes, "/usersblah")).toBeNull();
+  });
+});
+
+describe("trailing & duplicate slashes (normalized on both sides)", () => {
+  // TanStack distinguishes "/a" from "/a/"; we treat them as identical because
+  // `segments()` drops every empty token.
+  it("ignores a trailing slash on the pathname", () => {
+    const routes = r({ path: "a/b", component: "ab" });
+    expect(chain(matchRoutes(routes, "/a/b/"))).toEqual(["ab"]);
+  });
+
+  it("ignores a trailing slash declared on the route", () => {
+    const routes = r({ path: "a/", component: "a" });
+    expect(chain(matchRoutes(routes, "/a"))).toEqual(["a"]);
+    expect(chain(matchRoutes(routes, "/a/"))).toEqual(["a"]);
+  });
+
+  it("ignores a missing leading slash and collapses interior empties", () => {
+    const routes = r({ path: "a/b", component: "ab" });
+    expect(chain(matchRoutes(routes, "a/b"))).toEqual(["ab"]);
+    expect(chain(matchRoutes(routes, "/a//b"))).toEqual(["ab"]);
+    expect(chain(matchRoutes(routes, "///a///b///"))).toEqual(["ab"]);
+  });
+});
+
+describe("dynamic params", () => {
+  it("captures single and multiple params", () => {
+    expect(
+      matchRoutes(r({ path: "a/:id", component: "x" }), "/a/1")?.params,
+    ).toEqual({
+      id: "1",
+    });
+    expect(
+      matchRoutes(r({ path: "a/:id/b/:other", component: "x" }), "/a/1/b/2")
+        ?.params,
+    ).toEqual({ id: "1", other: "2" });
+  });
+
+  it("lets a later duplicate param name overwrite the earlier one", () => {
+    // Mirrors TanStack `'/a/$id/b/$id'` -> `{ id: '2' }`.
+    expect(
+      matchRoutes(r({ path: "a/:id/b/:id", component: "x" }), "/a/1/b/2")
+        ?.params,
+    ).toEqual({ id: "2" });
+  });
+
+  it("captures the raw segment text without trimming trailing characters", () => {
+    expect(
+      matchRoutes(r({ path: "a/:id", component: "x" }), "/a/1_")?.params,
+    ).toEqual({
+      id: "1_",
+    });
+  });
+
+  it("requires a value for a param segment (no zero-length match)", () => {
+    // "/users" cannot satisfy "users/:id" — the param segment has no value.
+    expect(
+      matchRoutes(r({ path: "users/:id", component: "x" }), "/users"),
+    ).toBeNull();
+  });
+
+  it("captures values with hyphens, underscores and symbols verbatim", () => {
+    // Ported from wouter: a param matches the whole segment, so punctuation
+    // and symbols inside a value are captured (and decoded) as-is.
+    expect(
+      matchRoutes(r({ path: "users/:name", component: "x" }), "/users/1-alex")
+        ?.params,
+    ).toEqual({ name: "1-alex" });
+    expect(
+      matchRoutes(
+        r({ path: "users/:name/bio", component: "x" }),
+        "/users/$102_Kathrine&/bio",
+      )?.params,
+    ).toEqual({ name: "$102_Kathrine&" });
+  });
+
+  describe("decoding", () => {
+    it("decodes %20 to a space in a param", () => {
+      expect(
+        matchRoutes(
+          r({ path: "users/:name", component: "x" }),
+          "/users/John%20Doe",
+        )?.params,
+      ).toEqual({ name: "John Doe" });
+    });
+
+    it("decodes an encoded slash without splitting the segment", () => {
+      // "%2F" is literal text in the pathname, so it is one segment that
+      // decodes to contain a "/".
+      expect(
+        matchRoutes(r({ path: "users/:id", component: "x" }), "/users/a%2Fb")
+          ?.params,
+      ).toEqual({ id: "a/b" });
+    });
+
+    it("leaves '+' untouched (decodeURIComponent does not treat it as space)", () => {
+      expect(
+        matchRoutes(r({ path: "users/:id", component: "x" }), "/users/a+b")
+          ?.params,
+      ).toEqual({ id: "a+b" });
+    });
+  });
+});
+
+describe("splat / wildcard", () => {
+  it("captures the remaining segments joined by '/'", () => {
+    expect(
+      matchRoutes(r({ path: "a/*", component: "x" }), "/a/b/c")?.params,
+    ).toEqual({
+      "*": "b/c",
+    });
+  });
+
+  // TanStack: both "/a" and "/a/" against "/a/$" capture "".
+  it("captures an empty string when nothing remains, with or without a trailing slash", () => {
+    const routes = r({ path: "a/*", component: "x" });
+    expect(matchRoutes(routes, "/a")?.params).toEqual({ "*": "" });
+    expect(matchRoutes(routes, "/a/")?.params).toEqual({ "*": "" });
+  });
+
+  it("decodes each captured segment", () => {
+    // From TanStack path.test: parentheses survive, spaces/brackets decode.
+    expect(
+      matchRoutes(
+        r({ path: "docs/*", component: "x" }),
+        "/docs/file%20(copy)%20%5B2%5D.pdf",
+      )?.params,
+    ).toEqual({ "*": "file (copy) [2].pdf" });
+  });
+
+  it("does not let an asterisk inside a param value disturb a later splat", () => {
+    // react-router `'/users/:name/*'` vs `'/users/foo*/splat'`.
+    expect(
+      matchRoutes(
+        r({ path: "users/:name/*", component: "x" }),
+        "/users/foo*/splat",
+      )?.params,
+    ).toEqual({ name: "foo*", "*": "splat" });
+  });
+});
+
+describe("case sensitivity (DIVERGENCE: we are case-sensitive)", () => {
+  // react-router matches "/systemdashboard" against "/SystemDashboard" by
+  // default; we require an exact-case match on static segments.
+  it("rejects a case-mismatched static segment", () => {
+    expect(
+      matchRoutes(
+        r({ path: "SystemDashboard", component: "x" }),
+        "/systemdashboard",
+      ),
+    ).toBeNull();
+    expect(matchRoutes(r({ path: "a/b", component: "x" }), "/A/B")).toBeNull();
+  });
+});
+
+describe("ranking / specificity (most specific wins, regardless of order)", () => {
+  it("prefers a static segment over a param", () => {
+    const routes = r(
+      { path: ":id", component: "param" },
+      { path: "new", component: "static" },
+    );
+    expect(chain(matchRoutes(routes, "/new"))).toEqual(["static"]);
+    expect(chain(matchRoutes(routes, "/123"))).toEqual(["param"]);
+  });
+
+  it("prefers a param over a splat", () => {
+    const routes = r(
+      { path: "*", component: "splat" },
+      { path: ":id", component: "param" },
+    );
+    expect(chain(matchRoutes(routes, "/123"))).toEqual(["param"]);
+  });
+
+  it("prefers the route with more static segments at equal depth", () => {
+    const routes = r(
+      { path: "a/:x", component: "param" },
+      { path: "a/b", component: "static" },
+    );
+    expect(chain(matchRoutes(routes, "/a/b"))).toEqual(["static"]);
+  });
+
+  it("breaks an exact-score tie by source order", () => {
+    // ":id/b" and "a/:x" both score static+param for "/a/b"; first declared wins.
+    const routes = r(
+      { path: ":id/b", component: "first" },
+      { path: "a/:x", component: "second" },
+    );
+    const match = matchRoutes(routes, "/a/b");
+    expect(chain(match)).toEqual(["first"]);
+    expect(match?.params).toEqual({ id: "a" });
+  });
+});
+
+describe("nested routes, index & splat fallback", () => {
+  it("matches an index route only when the parent path is fully consumed", () => {
+    const routes = r({
+      path: "users",
+      component: "layout",
+      children: [
+        { index: true, component: "list" },
+        { path: ":id", component: "detail" },
+      ],
+    });
+    expect(chain(matchRoutes(routes, "/users"))).toEqual(["layout", "list"]);
+    expect(chain(matchRoutes(routes, "/users/42"))).toEqual([
+      "layout",
+      "detail",
+    ]);
+  });
+
+  it("bubbles parent params down into the matched child", () => {
+    const routes = r({
+      path: "users/:userId",
+      component: "userLayout",
+      children: [{ path: "posts/:postId", component: "post" }],
+    });
+    const match = matchRoutes(routes, "/users/42/posts/7");
+    expect(chain(match)).toEqual(["userLayout", "post"]);
+    expect(match?.params).toEqual({ userId: "42", postId: "7" });
+  });
+
+  it("falls back to a root splat when no specific route matches", () => {
+    const routes = r(
+      { path: "users/:id", component: "user" },
+      { path: "*", component: "notFound" },
+    );
+    expect(chain(matchRoutes(routes, "/about/team"))).toEqual(["notFound"]);
+    expect(matchRoutes(routes, "/about/team")?.params).toEqual({
+      "*": "about/team",
+    });
+  });
+});

--- a/packages/core/test/unit/matcher/property.test.ts
+++ b/packages/core/test/unit/matcher/property.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Property-based proof of the matcher's core invariant. "Bulletproof" is a
+ * property of the *pair* (route config × pathname), so example-based tests —
+ * which pin one config — can only ever sample the space. Here we let fast-check
+ * generate thousands of random route trees crossed with random adversarial
+ * pathnames and assert, for every pair, that `matchRoutes`:
+ *
+ *   1. never throws,
+ *   2. terminates promptly (a hang would trip the wall-clock guard / vitest
+ *      timeout), and
+ *   3. returns either `null` or a well-formed `{ chain, params }`.
+ *
+ * Route-tree depth is bounded deliberately: recursion follows the (developer-
+ * authored) config, not the URL, so unbounded depth would only prove that *we*
+ * can blow our own stack — not a property of hostile input.
+ */
+
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { matchRoutes } from "../../../src/matcher";
+import type { RouteConfig } from "../../../src/types";
+
+// ─── Arbitraries ──────────────────────────────────────────────────────────────
+
+const ROUTE_PATH = fc
+  .array(fc.constantFrom("a", "b", "users", "files", ":id", ":name", "*"), {
+    minLength: 1,
+    maxLength: 3,
+  })
+  .map((segs) => segs.join("/"));
+
+function routeArb(depth: number): fc.Arbitrary<RouteConfig<string>> {
+  const leaf = fc.record({ path: ROUTE_PATH, component: fc.constant("c") });
+  const index = fc.record({
+    index: fc.constant(true),
+    component: fc.constant("idx"),
+  });
+  if (depth <= 0) return fc.oneof(leaf, index);
+
+  const layout = fc.record({
+    path: ROUTE_PATH,
+    component: fc.option(fc.constant("c"), { nil: undefined }),
+    children: fc.array(routeArb(depth - 1), { minLength: 1, maxLength: 3 }),
+  });
+  return fc.oneof(leaf, index, layout);
+}
+
+const ROUTES = fc.array(routeArb(3), { minLength: 1, maxLength: 4 });
+
+/** A pool of segment tokens spanning every way a pathname turns adversarial. */
+const NASTY_TOKEN = fc.constantFrom(
+  "a",
+  "b",
+  "users",
+  "files",
+  "123",
+  "%", // lone percent → would throw decodeURIComponent
+  "%zz", // bad hex
+  "%C0%80", // invalid UTF-8
+  "%2F", // encoded slash
+  "%20", // encoded space
+  "..", // traversal
+  "%2e%2e",
+  "<script>",
+  "café",
+  "😀", // astral / surrogate pair
+  " ", // NUL
+  "‮", // RTL override
+  "​", // zero-width space
+  "   ", // whitespace
+  "*",
+  ":id",
+  "?q=1", // query residue
+  "#frag", // hash residue
+);
+
+const PATHNAME = fc.oneof(
+  // Structured: random leading/trailing/interior slashes around nasty tokens.
+  fc
+    .tuple(
+      fc.constantFrom("/", "//", "", "/a/"),
+      fc.array(fc.oneof(NASTY_TOKEN, fc.string()), { maxLength: 10 }),
+      fc.constantFrom("", "/", "//", "///"),
+    )
+    .map(([lead, segs, trail]) => lead + segs.join("/") + trail),
+  // Totally arbitrary strings — the matcher must accept literally anything.
+  fc.string(),
+);
+
+// ─── Properties ───────────────────────────────────────────────────────────────
+
+describe("matcher invariants (property-based)", () => {
+  it("never throws, terminates, and returns null or a well-formed match", () => {
+    fc.assert(
+      fc.property(ROUTES, PATHNAME, (routes, pathname) => {
+        const start = performance.now();
+        const result = matchRoutes(routes, pathname); // a throw fails the property
+        const elapsed = performance.now() - start;
+
+        // Generated inputs are tiny; anything slow signals algorithmic blowup.
+        expect(elapsed).toBeLessThan(500);
+
+        if (result !== null) {
+          expect(Array.isArray(result.chain)).toBe(true);
+          expect(result.chain.length).toBeGreaterThan(0);
+          expect(result.params).toBeTypeOf("object");
+          expect(result.params).not.toBeNull();
+        }
+      }),
+      { numRuns: 2000 },
+    );
+  });
+
+  it("is deterministic: the same pair always yields the same result", () => {
+    fc.assert(
+      fc.property(ROUTES, PATHNAME, (routes, pathname) => {
+        expect(matchRoutes(routes, pathname)).toEqual(
+          matchRoutes(routes, pathname),
+        );
+      }),
+      { numRuns: 1000 },
+    );
+  });
+});

--- a/packages/core/test/unit/matcher/stress.test.ts
+++ b/packages/core/test/unit/matcher/stress.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Stress / fuzz suite for the SPA matcher.
+ *
+ * Goal (per the Navigation API contract): the matcher is fed `url.pathname`
+ * straight from the engine on every navigation. `URL` parsing does NOT validate
+ * percent-encoding, normalize away `//`, strip control characters, or reject
+ * astral/RTL/zero-width code points — all of that survives into `pathname`. So
+ * the matcher must, for *any* string:
+ *   1. terminate (never spin in an infinite loop), and
+ *   2. return either `null` or a well-formed `RouteMatch` (never crash).
+ *
+ * The route table mirrors a realistic `as const` config: static, index, param,
+ * nested, splat, and a root catch-all so hostile input has somewhere to land.
+ */
+
+import { describe, expect, it } from "vitest";
+import { matchRoutes } from "../../../src/matcher";
+import type { RouteConfig } from "../../../src/types";
+
+const routes = [
+  { path: "/", component: "home" },
+  { path: "about", component: "about" },
+  {
+    path: "users",
+    component: "usersLayout",
+    children: [
+      { index: true, component: "userList" },
+      { path: ":id", component: "userDetail" },
+    ],
+  },
+  { path: "files/*", component: "files" },
+  { path: "*", component: "notFound" },
+] as const satisfies readonly RouteConfig<string>[];
+
+/** A result is well-formed when it is `null` or a non-empty chain + params object. */
+function assertWellFormed(result: ReturnType<typeof matchRoutes>): void {
+  if (result === null) return;
+  expect(Array.isArray(result.chain)).toBe(true);
+  expect(result.chain.length).toBeGreaterThan(0);
+  expect(result.params).toBeTypeOf("object");
+  expect(result.params).not.toBeNull();
+}
+
+/**
+ * Inputs the matcher must survive without throwing. Each is a real-world way a
+ * pathname turns adversarial: unicode/normalization, control & bidi code points,
+ * XSS/template-injection literals, slash abuse, query/hash residue treated as
+ * literal text, path-traversal sequences, and pathological size.
+ */
+const SAFE_PATHS: readonly (readonly [name: string, path: string])[] = [
+  // --- Unicode, normalization & control characters ---
+  ["NFC composed (café)", "/café"],
+  ["NFD decomposed (cafe + combining acute)", "/café"],
+  ["astral / surrogate pair (emoji)", "/😀"],
+  ["percent-encoded emoji", "/%F0%9F%98%80"],
+  ["percent-encoded snowman", "/%E2%98%83"],
+  ["right-to-left override", "/‮evil"],
+  ["zero-width space inside segment", "/a​b"],
+  ["literal NUL code point", "/ "],
+  ["percent-encoded NUL", "/%00"],
+  ["ligature (fi)", "/ﬁle"],
+
+  // --- XSS / injection literals (must be inert text, never executed) ---
+  ["raw <script> tag", "/<script>alert(1)</script>"],
+  ["encoded <script> tag", "/%3Cscript%3Ealert(1)%3C%2Fscript%3E"],
+  ["javascript: pseudo-scheme", "/javascript:alert(document.cookie)"],
+  ["img onerror breakout", '/"><img src=x onerror=alert(1)>'],
+  ["svg onload breakout", "/'><svg/onload=alert(1)>"],
+  ["__proto__ as param value", "/users/__proto__"],
+  ["constructor as param value", "/users/constructor"],
+  ["template-literal injection", "/${alert(1)}"],
+
+  // --- Slash abuse, empties & trailing slashes ---
+  ["empty string", ""],
+  ["bare root", "/"],
+  ["double slash", "//"],
+  ["triple slash", "///"],
+  ["empty interior segment", "/a//b"],
+  ["slashes everywhere", "///a///b///"],
+  ["many trailing slashes", "/a/b/////"],
+  ["whitespace-only", "   "],
+
+  // --- Query / hash residue (matcher must treat as literal, not parse) ---
+  ["open-redirect-ish query", "/users/42?redirect=//evil.com"],
+  ["hash fragment", "/path#section"],
+  ["query + hash with slashes", "/a?b=c&d=e#f/g/h"],
+  ["matrix parameter", "/users/42;jsessionid=abc123"],
+
+  // --- Path traversal & encoded slashes (matched literally, never resolved) ---
+  ["encoded double-slash param", "/users/%2F%2Fadmin"],
+  ["encoded traversal in splat", "/files/..%2f..%2f..%2fetc%2fpasswd"],
+  ["literal traversal in splat", "/files/../../../etc/passwd"],
+  ["mixed encoded dot-segments", "/users/.%2e/.%2e/admin"],
+
+  // --- Pathological size / depth (must stay fast, never hang) ---
+  ["1k repeated segments", "/" + "a/".repeat(1000)],
+  ["10k repeated segments", "/" + "seg/".repeat(10000)],
+  ["100k-char single segment", "/" + "x".repeat(100000)],
+  ["10k astral chars in a param", "/users/" + "💀".repeat(10000)],
+
+  // --- Malformed percent-encoding (decoded leniently, never throws) ---
+  // `decodeURIComponent` would raise URIError on these; the matcher guards it
+  // and falls back to the raw segment, so matching still resolves. See the
+  // `safeDecode` helper in matcher.ts.
+  ["lone percent", "/%"],
+  ["bad hex digits", "/%zz"],
+  ["truncated escape", "/%2"],
+  ["non-hex after percent", "/%G0"],
+  ["overlong UTF-8", "/%C0%80"],
+  ["truncated multibyte UTF-8", "/%E0%A4%A"],
+  ["lone UTF-16 surrogate", "/%ED%A0%80"],
+  ["invalid lead byte 0xFF", "/%FF"],
+  ["malformed % in param position", "/users/%"],
+  ["malformed % in splat position", "/files/a/%/b"],
+  ["malformed % in query residue", "/search?q=%"],
+  ["malformed % in hash residue", "/x#%"],
+];
+
+describe("matcher stress test", () => {
+  describe("never crashes and returns a well-formed result on hostile input", () => {
+    it.each(SAFE_PATHS)("survives: %s", (_name, path) => {
+      let result: ReturnType<typeof matchRoutes> = null;
+      expect(() => {
+        result = matchRoutes(routes, path);
+      }).not.toThrow();
+      assertWellFormed(result);
+    });
+  });
+
+  describe("terminates promptly on pathological input (no infinite loop)", () => {
+    // Recursion is bounded by the (finite) route tree and path segments only
+    // shrink, so a hang would signal a real regression. A generous wall-clock
+    // budget catches accidental O(n²) blowups without being flaky.
+    it.each(SAFE_PATHS.filter(([n]) => /repeated|char|astral/.test(n)))(
+      "completes fast: %s",
+      (_name, path) => {
+        const start = performance.now();
+        matchRoutes(routes, path);
+        expect(performance.now() - start).toBeLessThan(1000);
+      },
+    );
+  });
+});


### PR DESCRIPTION
**Fix:** guard `decodeURIComponent` against malformed percent-encoding. A pathname containing a lone `%`, bad hex digits or invalid UTF-8 bytes (all valid per the Navigation API — `url.pathname` is verbatim) previously threw `URIError` mid-match and crashed navigation. `safeDecode` falls back to the raw segment so matching always resolves cleanly.

**Tests:** restructured into `test/unit/matcher/` with four focused files:
- `basic.test.ts`      — baseline spec for every matcher feature
- `edge-cases.test.ts` — ports from react-router, TanStack & wouter
                         (params, wildcards, slashes, special chars)
- `stress.test.ts`     — 50 adversarial paths (XSS, traversal, huge inputs,
                         malformed %-encoding, unicode/RTL/zero-width)
- `property.test.ts`   — fast-check: 3 000 random config×pathname pairs
                         prove the invariant (no throw, terminates, well-formed)

**Style:** added module JSDoc, section dividers and @param/@returns to `matchRoutes`; `SegmentMatch` moved next to `matchSegments`.