### PR TITLE
docs: replace logo with relay/dotted-i mark and update brand palette

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   metaChunk: true,
 
   head: [
-    ["meta", { name: "theme-color", content: "#646cff" }],
+    ["meta", { name: "theme-color", content: "#6366F1" }],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { property: "og:title", content: "isorouter" }],
     ["meta", { property: "og:description", content: ogDescription }],
@@ -28,7 +28,7 @@ export default defineConfig({
     ["meta", { name: "twitter:description", content: ogDescription }],
     [
       "link",
-      { rel: "icon", type: "image/svg+xml", href: "/isorouter/logo.svg" },
+      { rel: "icon", type: "image/svg+xml", href: "/isorouter/favicon.svg" },
     ],
   ],
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,44 +1,65 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;600&display=swap');
+
 /**
- * Brand palette — derived from the logo (periwinkle cube accent #7B8EFB /
- * highlight #9EABFC; light-theme stroke #4A5CE8). Drives links, buttons, the
- * hero gradient and active nav state so the whole site matches the mark.
+ * Brand palette — cyan→indigo gradient line, magenta nodes (synthwave / midnight-cyber).
+ * Drives links, buttons, the hero gradient and active nav state.
  */
 :root {
-  --vp-c-brand-1: #4a5ce8;
-  --vp-c-brand-2: #5a6cf5;
-  --vp-c-brand-3: #7b8efb;
-  --vp-c-brand-soft: rgba(123, 142, 251, 0.14);
+  --vp-c-brand-1: #4F46E5;
+  --vp-c-brand-2: #6366F1;
+  --vp-c-brand-3: #818CF8;
+  --vp-c-brand-soft: rgba(99, 102, 241, 0.14);
 
-  /* Home hero gradient on the (replaced) wordmark / accents. */
   --vp-home-hero-name-color: var(--vp-c-brand-1);
 }
 
 .dark {
-  --vp-c-brand-1: #9eabfc;
-  --vp-c-brand-2: #7b8efb;
-  --vp-c-brand-3: #6b7cfb;
-  --vp-c-brand-soft: rgba(123, 142, 251, 0.18);
+  --vp-c-brand-1: #22D3EE;
+  --vp-c-brand-2: #67E8F9;
+  --vp-c-brand-3: #A5F3FC;
+  --vp-c-brand-soft: rgba(34, 211, 238, 0.18);
+
+  /* Cyan is too bright for white text — use dark text on brand buttons */
+  --vp-button-brand-text: #0A0712;
+  --vp-button-brand-hover-text: #0A0712;
+  --vp-button-brand-active-text: #0A0712;
 }
 
 /**
- * The "isorouter" wordmark: "iso" in the brand accent, "router" in the
- * foreground colour — bold and tightly tracked, matching the logo guide.
+ * The "isorouter" wordmark: "iso" weight 300 muted, "router" weight 600 full-strength.
+ * Matches the design handoff typography spec (Space Grotesk, tracking −0.04em).
  */
 .iso-wordmark {
-  font-weight: 800;
-  letter-spacing: -0.02em;
+  font-family: 'Space Grotesk', sans-serif;
+  letter-spacing: -0.04em;
   white-space: nowrap;
 }
 
 .iso-wordmark .iso {
-  color: var(--vp-c-brand-1);
+  font-weight: 400;
+  background: linear-gradient(to right, #06B6D4, #DB2777);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.dark .iso-wordmark .iso {
+  background: linear-gradient(to right, #22D3EE, #EC4899);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .iso-wordmark .rest {
-  color: var(--vp-c-text-1);
+  font-weight: 600;
+  color: #14131A;
 }
 
-/* In the nav bar, sit next to the cube logo. */
+.dark .iso-wordmark .rest {
+  color: #F4F5FB;
+}
+
+/* In the nav bar, sit next to the relay logo. */
 .VPNavBarTitle .iso-wordmark {
   font-size: 18px;
   margin-left: 8px;

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="isorouter">
+  <polyline points="24,80 24,52 76,52 76,44" fill="none" stroke="#22D3EE" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"></polyline>
+  <circle cx="50" cy="52" r="11" fill="#F472B6"></circle>
+  <circle cx="76" cy="24" r="9" fill="#EC4899"></circle>
+</svg>

--- a/docs/public/logo-light.svg
+++ b/docs/public/logo-light.svg
@@ -1,10 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="isorouter">
-  
-  <polygon points="15.4,30 50,50 50,90 15.4,70" fill="#0C1D35"></polygon>
-  <polygon points="84.6,30 84.6,70 50,90 50,50" fill="#173462"></polygon>
-  <polygon points="50,10 84.6,30 50,50 15.4,30" fill="#7B8EFB"></polygon>
-  <polyline points="50,10 84.6,30 50,50 15.4,30 50,10" fill="none" stroke="#4A5CE8" stroke-width="1.3" stroke-linejoin="round"></polyline>
-  <polyline points="84.6,30 84.6,70 50,90 15.4,70 15.4,30" fill="none" stroke="rgba(0,0,0,0.1)" stroke-width="0.8"></polyline>
-  <line x1="50" y1="90" x2="50" y2="50" stroke="rgba(0,0,0,0.1)" stroke-width="0.8"></line>
-  <circle cx="50" cy="50" r="4.5" fill="white"></circle>
+  <defs>
+    <linearGradient id="iso-line-l" x1="22" y1="80" x2="78" y2="22" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0891B2"></stop>
+      <stop offset="1" stop-color="#4F46E5"></stop>
+    </linearGradient>
+  </defs>
+  <polyline points="22,80 22,50 78,50 78,38" fill="none" stroke="url(#iso-line-l)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></polyline>
+  <circle cx="22" cy="80" r="6" fill="#0891B2"></circle>
+  <circle cx="50" cy="50" r="8" fill="#DB2777"></circle>
+  <circle cx="78" cy="22" r="6.5" fill="#BE185D"></circle>
 </svg>

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,10 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="isorouter">
-  
-  <polygon points="15.4,30 50,50 50,90 15.4,70" fill="#0C1D35"></polygon>
-  <polygon points="84.6,30 84.6,70 50,90 50,50" fill="#173462"></polygon>
-  <polygon points="50,10 84.6,30 50,50 15.4,30" fill="#7B8EFB"></polygon>
-  <polyline points="50,10 84.6,30 50,50 15.4,30 50,10" fill="none" stroke="#9EABFC" stroke-width="1.3" stroke-linejoin="round"></polyline>
-  <polyline points="84.6,30 84.6,70 50,90 15.4,70 15.4,30" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.8"></polyline>
-  <line x1="50" y1="90" x2="50" y2="50" stroke="rgba(255,255,255,0.1)" stroke-width="0.8"></line>
-  <circle cx="50" cy="50" r="4.5" fill="#BEC7FE"></circle>
+  <defs>
+    <linearGradient id="iso-line" x1="22" y1="80" x2="78" y2="22" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#22D3EE"></stop>
+      <stop offset="1" stop-color="#6366F1"></stop>
+    </linearGradient>
+  </defs>
+  <polyline points="22,80 22,50 78,50 78,38" fill="none" stroke="url(#iso-line)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></polyline>
+  <circle cx="22" cy="80" r="6" fill="#22D3EE"></circle>
+  <circle cx="50" cy="50" r="8" fill="#F472B6"></circle>
+  <circle cx="78" cy="22" r="6.5" fill="#EC4899"></circle>
 </svg>


### PR DESCRIPTION
Swap the isometric cube for the new synthwave/midnight-cyber mark (cyan→indigo gradient line, magenta nodes). Add favicon.svg (32px-tuned, stroke-width 9, 2 nodes). Update VitePress config to use favicon.svg, theme-color to #6366F1. Rework brand palette in custom.css to match new design tokens; wordmark "iso" gets a cyan→pink gradient (weight 400) for readability on both dark and light backgrounds.