### PR TITLE
chore(core): name status/scroll types, extract intercept predicate

### DIFF
--- a/.changeset/named-status-scroll-types.md
+++ b/.changeset/named-status-scroll-types.md
@@ -1,0 +1,8 @@
+---
+"@isorouter/core": minor
+---
+
+Export `RouterStatus` and `ScrollMode` as named types. These were previously
+inline string-literal unions on `RouterSnapshot.status` and `RouterOptions.scroll`;
+naming and exporting them lets consumers reference the exact value sets directly
+(e.g. when narrowing on `status` or typing a `scroll` option). No runtime change.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,4 +21,6 @@ export type {
   RouteTemplate,
   RouterOptions,
   RouterSnapshot,
+  RouterStatus,
+  ScrollMode,
 } from "./types";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
+/** Public surface / barrel export for @isorouter/core. */
+
 export {
   Router,
   createCoreRouter,

--- a/packages/core/src/lazy.ts
+++ b/packages/core/src/lazy.ts
@@ -1,3 +1,8 @@
+/**
+ * Lazy-component wrapper for @isorouter/core.
+ * Boxes a dynamic `import()` call so the router can resolve and cache it on demand.
+ */
+
 const LAZY = Symbol.for("isorouter.lazy");
 
 export interface LazyComponent<C = unknown> {

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -1,3 +1,12 @@
+/**
+ * Framework-agnostic router implementation for @isorouter/core.
+ *
+ * Wires the Navigation API to the route-matching algorithm: intercepts
+ * `navigate` events, runs `beforeLoad` guards (root → leaf), resolves lazy
+ * components, and publishes immutable snapshots to subscribers so it can plug
+ * directly into `useSyncExternalStore`, `createSubscriber`, `shallowRef`, etc.
+ */
+
 import { isLazy, type LazyComponent } from "./lazy";
 import { matchRoutes } from "./matcher";
 
@@ -9,6 +18,8 @@ import type {
   RouterOptions,
   RouterSnapshot,
 } from "./types";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 export type Unsubscribe = () => void;
 
@@ -23,11 +34,12 @@ function normalizePath(p: string): string {
   return p.replace(/\/+$/, "") || "/";
 }
 
+// ─── Public API ───────────────────────────────────────────────────────────────
+
 /**
  * Framework-agnostic router built on the Navigation API.
  * Generic over the component type `C`; adapters fix `C` (Svelte/React/Vue).
- * State is published as an immutable snapshot (stable reference until it changes)
- * so it plugs into `useSyncExternalStore`, `createSubscriber`, `shallowRef`, etc.
+ * State is published as an immutable snapshot (stable reference until it changes).
  */
 export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
   readonly routes: T;
@@ -50,7 +62,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
     };
   }
 
-  /* ---------------- external-store contract ---------------- */
+  // ─── External-Store Contract ──────────────────────────────────────────────
 
   subscribe = (fn: (s: RouterSnapshot<C>) => void): Unsubscribe => {
     this.#subs.add(fn);
@@ -67,7 +79,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
     for (const fn of this.#subs) fn(this.#snapshot);
   }
 
-  /* ---------------- lifecycle ---------------- */
+  // ─── Lifecycle ────────────────────────────────────────────────────────────
 
   start(): void {
     if (this.#started || !globalThis.navigation) return;
@@ -83,7 +95,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
     globalThis.navigation?.removeEventListener("navigate", this.#listener);
   }
 
-  /* ---------------- imperative navigation ---------------- */
+  // ─── Imperative Navigation ────────────────────────────────────────────────
 
   navigate(
     to: NavTarget<T>,
@@ -114,7 +126,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
     return result;
   }
 
-  /* ---------------- active-link helper ---------------- */
+  // ─── Active-Link Helper ───────────────────────────────────────────────────
 
   isActive(href: string, opts: { exact?: boolean } = {}): boolean {
     const target = normalizePath(
@@ -125,7 +137,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
     return path === target || path.startsWith(target + "/");
   }
 
-  /* ---------------- interception ---------------- */
+  // ─── Interception ─────────────────────────────────────────────────────────
 
   #onNavigate(e: NavigateEvent): void {
     if (
@@ -145,7 +157,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
     });
   }
 
-  /* ---------------- commit state machine ---------------- */
+  // ─── Commit State Machine ─────────────────────────────────────────────────
 
   async #commit(
     url: URL,

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -34,6 +34,21 @@ function normalizePath(p: string): string {
   return p.replace(/\/+$/, "") || "/";
 }
 
+/**
+ * Navigations the router must leave to the browser: cross-document or otherwise
+ * uninterceptable nav, in-page hash changes, downloads, and same-document form
+ * submissions (which should reach the server). Cheap boolean checks only — the
+ * origin check lives in #onNavigate since it needs the parsed destination URL.
+ */
+function shouldNotIntercept(e: NavigateEvent): boolean {
+  return (
+    !e.canIntercept ||
+    e.hashChange ||
+    e.downloadRequest != null || // download attr present: filename, or "" for bare `download`
+    e.formData != null // POST form submission carries an entry list — let it reach the server
+  );
+}
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /**
@@ -48,7 +63,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
   #subs = new Set<(s: RouterSnapshot<C>) => void>();
   #commitAbort: AbortController | null = null;
   #started = false;
-  #listener = (e: Event) => this.#onNavigate(e as NavigateEvent);
+  #listener = (e: NavigateEvent) => this.#onNavigate(e);
 
   constructor(routes: T, options: RouterOptions = {}) {
     this.routes = routes;
@@ -66,6 +81,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
 
   subscribe = (fn: (s: RouterSnapshot<C>) => void): Unsubscribe => {
     this.#subs.add(fn);
+
     return () => {
       this.#subs.delete(fn);
     };
@@ -76,6 +92,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
 
   #emit(patch: Partial<RouterSnapshot<C>>): void {
     this.#snapshot = { ...this.#snapshot, ...patch };
+
     for (const fn of this.#subs) fn(this.#snapshot);
   }
 
@@ -83,14 +100,18 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
 
   start(): void {
     if (this.#started || !globalThis.navigation) return;
+
     this.#started = true;
+
     navigation.addEventListener("navigate", this.#listener);
     void this.#commit(new URL(location.href), "reload");
   }
 
   stop(): void {
     if (!this.#started) return;
+
     this.#started = false;
+
     this.#commitAbort?.abort();
     globalThis.navigation?.removeEventListener("navigate", this.#listener);
   }
@@ -105,6 +126,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
       throw new Error(
         "[isorouter] Navigation API unavailable — load a polyfill",
       );
+
     return this.#navigateRaw(to, opts.replace ?? false, opts.state);
   }
 
@@ -122,7 +144,9 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
       state,
       info,
     });
+
     result.finished?.catch(NOOP); // swallow AbortError when superseded/cancelled
+
     return result;
   }
 
@@ -133,22 +157,19 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
       new URL(href, this.#snapshot.url.origin).pathname,
     );
     const path = normalizePath(this.#snapshot.url.pathname);
+
     if (opts.exact || target === "/") return path === target;
+
     return path === target || path.startsWith(target + "/");
   }
 
   // ─── Interception ─────────────────────────────────────────────────────────
 
   #onNavigate(e: NavigateEvent): void {
-    if (
-      !e.canIntercept ||
-      e.hashChange ||
-      e.downloadRequest != null || // string (incl. "") for downloads; null/undefined otherwise
-      e.formData // let same-document form submissions hit the server
-    )
-      return;
+    if (shouldNotIntercept(e)) return;
 
     const url = new URL(e.destination.url);
+
     if (url.origin !== location.origin) return;
 
     e.intercept({
@@ -165,11 +186,13 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
     external?: AbortSignal,
   ): Promise<void> {
     this.#commitAbort?.abort();
-    const ac = new AbortController();
-    this.#commitAbort = ac;
-    external?.addEventListener("abort", () => ac.abort(), { once: true });
-    const { signal } = ac;
 
+    const abortController = new AbortController();
+    this.#commitAbort = abortController;
+
+    external?.addEventListener("abort", () => abortController.abort(), {
+      once: true,
+    });
     this.#emit({ status: "navigating" });
 
     try {
@@ -190,18 +213,22 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
         params: matched.params,
         url,
         pathname: url.pathname,
-        signal,
+        signal: abortController.signal,
         navigationType,
       };
 
       for (const route of matched.chain) {
         if (!route.beforeLoad) continue;
+
         const result = await route.beforeLoad(ctx);
-        if (signal.aborted) return;
+
+        if (abortController.signal.aborted) return;
+
         if (result === false) {
           this.#navigateRaw(this.#snapshot.url.href, true); // restore
           return;
         }
+
         if (typeof result === "string") {
           this.#navigateRaw(result, true); // redirect
           return;
@@ -209,7 +236,7 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
       }
 
       const components = await this.#resolve(matched.chain);
-      if (signal.aborted) return;
+      if (abortController.signal.aborted) return;
 
       this.#emit({
         components,
@@ -218,10 +245,12 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
         status: "idle",
         error: null,
       });
+
       this.#applyTitle(matched.chain, ctx);
       this.#options.onCommit?.(this.#snapshot);
     } catch (err) {
-      if (signal.aborted) return;
+      if (abortController.signal.aborted) return;
+
       this.#emit({
         components: [],
         params: {},
@@ -238,11 +267,15 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
       (r): r is RouteConfig<C> & { component: C | LazyComponent<C> } =>
         r.component != null,
     );
+
     return Promise.all(
       withComponent.map(async (r) => {
         const comp = r.component;
+
         if (!isLazy(comp)) return comp;
+
         comp.resolved ??= (await comp.load()).default;
+
         return comp.resolved;
       }),
     );
@@ -250,10 +283,14 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
 
   #applyTitle(chain: RouteConfig<C>[], ctx: GuardContext): void {
     if (typeof document === "undefined") return;
+
     for (let i = chain.length - 1; i >= 0; i--) {
       const t = chain[i]!.title;
+
       if (t == null) continue;
+
       document.title = typeof t === "function" ? t(ctx) : t;
+
       return;
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared types for @isorouter/core: route config, guard context, router
+ * options/snapshot, and compile-time path-template utilities.
+ */
+
 import type { LazyComponent } from "./lazy";
 
 export type Awaitable<T> = T | Promise<T>;
@@ -14,10 +19,10 @@ export interface GuardContext {
 }
 
 /**
- * Navigation guard. Runs root -> leaf before the matched components commit.
- *  - `undefined` / `true` -> allow
- *  - `false`              -> block (current URL is restored)
- *  - `string`             -> redirect (replace) to that path
+ * Navigation guard. Runs root → leaf before the matched components commit.
+ *  - `undefined` / `true` → allow
+ *  - `false`              → block (current URL is restored)
+ *  - `string`             → redirect (replace) to that path
  */
 export type BeforeLoad = (
   ctx: GuardContext,
@@ -53,9 +58,7 @@ export interface RouteMatch<C = unknown> {
   params: Record<string, string>;
 }
 
-/* ------------------------------------------------------------------ *
- * Compile-time path templates (independent of the component type C).
- * ------------------------------------------------------------------ */
+// ─── Compile-Time Path Templates ──────────────────────────────────────────────
 
 type SegParam<Seg extends string> = Seg extends `:${infer P extends string}`
   ? Record<P, string>
@@ -63,7 +66,7 @@ type SegParam<Seg extends string> = Seg extends `:${infer P extends string}`
     ? Record<"*", string>
     : Record<never, never>;
 
-/** `ExtractParams<'/concerts/:city'>` -> `{ city: string }` */
+/** `ExtractParams<'/concerts/:city'>` → `{ city: string }` */
 export type ExtractParams<Path extends string> =
   Path extends `${infer Seg}/${infer Rest}`
     ? SegParam<Seg> & ExtractParams<Rest>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -38,18 +38,24 @@ export interface RouteConfig<C = unknown> {
   children?: readonly RouteConfig<C>[];
 }
 
+/** Scroll handling after a committed navigation, forwarded to `intercept`. */
+export type ScrollMode = "after-transition" | "manual";
+
 export interface RouterOptions {
-  scroll?: "after-transition" | "manual";
+  scroll?: ScrollMode;
   onError?: (err: unknown) => void;
   onCommit?: (snapshot: RouterSnapshot<unknown>) => void;
 }
+
+/** Lifecycle state of the current navigation. */
+export type RouterStatus = "idle" | "navigating" | "not-found" | "error";
 
 export interface RouterSnapshot<C> {
   /** Components for the matched chain, in render order (component-less routes removed). */
   components: C[];
   params: Record<string, string>;
   url: URL;
-  status: "idle" | "navigating" | "not-found" | "error";
+  status: RouterStatus;
   error: unknown;
 }
 

--- a/packages/core/test/unit/lazy.test.ts
+++ b/packages/core/test/unit/lazy.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for `lazy` and `isLazy` from @isorouter/core.
+ */
+
 import { describe, expect, it, vi } from "vitest";
 import { isLazy, lazy, type LazyComponent } from "../../src/lazy";
 

--- a/packages/core/test/unit/router.test.ts
+++ b/packages/core/test/unit/router.test.ts
@@ -8,10 +8,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeNavigation } from "@isorouter/test-utils";
 import { lazy } from "../../src/lazy";
 import { createCoreRouter, Router } from "../../src/router";
 import type { GuardContext, RouteConfig } from "../../src/types";
-import { FakeNavigation } from "@isorouter/test-utils";
 
 let nav: FakeNavigation;
 
@@ -185,8 +185,10 @@ describe("#onNavigate interception guards", () => {
     await flush();
 
     const before = router.getSnapshot();
-    // @virtualstate/navigation reports "" (not null) for plain <a> clicks —
-    // treating any non-null value as a download is intentional, see README.
+    // Per spec, `<a download>` (bare attribute) yields downloadRequest === ""
+    // — a genuine download — so any non-null value is skipped. (The
+    // @virtualstate/navigation polyfill separately reports "" for plain clicks
+    // too, which is why link clicks degrade to full-page nav under it; see README.)
     nav.dispatchNavigate({
       destinationUrl: "http://localhost/about",
       downloadRequest: "",
@@ -196,7 +198,7 @@ describe("#onNavigate interception guards", () => {
     expect(router.getSnapshot()).toBe(before);
   });
 
-  it("ignores same-document form submissions", async () => {
+  it("ignores POST form submissions", async () => {
     const router = new Router(basicRoutes);
     router.start();
     await flush();

--- a/packages/core/test/unit/router.test.ts
+++ b/packages/core/test/unit/router.test.ts
@@ -1,3 +1,12 @@
+/**
+ * Integration tests for `Router` / `createCoreRouter` from @isorouter/core.
+ *
+ * Uses `FakeNavigation` from `@isorouter/test-utils` to drive the Navigation
+ * API without a real browser, covering the full lifecycle: start/stop, guard
+ * execution (root → leaf), lazy loading, abort races, and the external-store
+ * contract.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { lazy } from "../../src/lazy";
 import { createCoreRouter, Router } from "../../src/router";


### PR DESCRIPTION
## What

- Extract `#onNavigate`'s bail-out conditions into a module-level
  `shouldNotIntercept()` predicate (matches the existing `initialUrl` /
  `normalizePath` helper style).
- Add named types `RouterStatus` and `ScrollMode` for the previously inline
  unions on `RouterSnapshot.status` / `RouterOptions.scroll`, and export them.
- Drop the `as NavigateEvent` cast in `#listener` (`NavigationEventMap` already
  types it).
- Align interception comments with the WHATWG `NavigateEvent` spec wording
  (`downloadRequest === ""` for bare `download`, POST form submissions).

## Why

`RouterStatus` / `ScrollMode` let consumers reference the exact value sets
directly (e.g. narrowing on `status`, typing a `scroll` option). The rest is a
no-runtime-change refactor.

## Versioning

Changeset: `@isorouter/core` **minor**. Via `linked`, all packages bump to
**1.1.0**. No breaking changes — public API surface is only widened.