### PR TITLE
fix(core): reject cross-origin guard redirects

### DIFF
--- a/.changeset/cross-origin-redirect-guard.md
+++ b/.changeset/cross-origin-redirect-guard.md
@@ -1,0 +1,15 @@
+---
+"@isorouter/core": patch
+"@isorouter/react": patch
+"@isorouter/svelte": patch
+"@isorouter/vue": patch
+---
+
+Restrict `beforeLoad` guard redirects to same-origin targets, closing an
+open-redirect. When a guard returns a string, the router now resolves it against
+the current URL and throws if the result is cross-origin (including
+protocol-relative `//host` and `javascript:` URLs) instead of navigating — the
+snapshot moves to `status: "error"` / `onError` rather than sending visitors to an
+external site (e.g. via a user-derived `?next=` param). Same-origin and relative
+redirects are unchanged. The framework adapters are republished so the fix ships
+in a fresh adapter release for consumers that pin the adapter packages.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -59,7 +59,7 @@ export default defineConfig({
         ],
       },
       {
-        text: "v1.0.0",
+        text: "v1.1.1",
         items: [
           {
             text: "Changelog",

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -156,7 +156,9 @@ type BeforeLoad = (ctx: GuardContext) => Awaitable<void | boolean | string>;
 ```
 
 Return nothing/`true` to allow, `false` to block (current URL restored), or a
-`string` to redirect (`replace`). See [Navigation guards](../guide/guards).
+same-origin `string` to redirect (`replace`); a cross-origin string throws
+(`status: "error"`) rather than navigating. See
+[Navigation guards](../guide/guards).
 
 ## `lazy(loader)`
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -185,10 +185,15 @@ leaf and may be `async`. See [Navigation guards](./guards).
 
 ### How do I redirect safely?
 
-Return a path string from `beforeLoad`. If the redirect target is derived from
-user input (e.g. a `?next=` query param), **validate it yourself** — restrict it
-to a same-origin or relative path before returning it, exactly as you would with
-any server-side redirect. Don't hand an unchecked external URL to a redirect.
+Return a path string from `beforeLoad`. Redirects are restricted to **same-origin**
+targets: if a guard returns a cross-origin string (e.g. a `?next=https://evil.com`
+query param), the router throws instead of navigating — the snapshot goes to
+`status: "error"` rather than open-redirecting to the external site. So an
+unchecked `?next=` can't be turned into an open redirect.
+
+You should still validate user-derived targets against an allowlist of known
+paths if you want to control *which* same-origin routes are reachable — the
+origin check stops external redirects, not arbitrary internal ones.
 
 ### What is `ctx.signal` for?
 

--- a/docs/guide/guards.md
+++ b/docs/guide/guards.md
@@ -27,7 +27,7 @@ type BeforeLoad = (ctx: GuardContext) => Awaitable<void | boolean | string>;
 | ----------------- | ----------------------------------------------------- |
 | `undefined` / `true` | **Allow** the navigation.                          |
 | `false`           | **Block** — the current URL is restored.              |
-| `string`          | **Redirect** (via `replace`) to that path.            |
+| `string`          | **Redirect** (via `replace`) to that **same-origin** path. |
 
 ```ts twoslash
 import { createCoreRouter } from "@isorouter/core";
@@ -45,6 +45,15 @@ const router = createCoreRouter([
   },
 ] as const);
 ```
+
+::: warning Same-origin only
+A redirect string must resolve to the **same origin**. If a guard returns a
+cross-origin target (including protocol-relative `//host` or `javascript:` URLs),
+the router throws instead of navigating and the snapshot moves to
+`status: "error"` — this closes the open-redirect class where a user-derived
+`?next=` could send visitors to an external site. Same-origin and relative paths
+are unaffected.
+:::
 
 ## Async guards & the abort signal
 

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -230,6 +230,18 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
         }
 
         if (typeof result === "string") {
+          // Guard strings may be user-derived (e.g. a ?next= param); reject
+          // cross-origin targets so a guard can't be turned into an open
+          // redirect. Resolving against the current URL also catches
+          // protocol-relative (//evil.com) and opaque (javascript:) targets,
+          // whose origin won't match. Same-origin / relative paths pass through.
+          const target = new URL(result, this.#snapshot.url.href);
+          if (target.origin !== this.#snapshot.url.origin)
+            throw new Error(
+              `[isorouter] beforeLoad returned a cross-origin redirect ` +
+                `("${result}"); only same-origin paths are allowed`,
+            );
+
           this.#navigateRaw(result, true); // redirect
           return;
         }

--- a/packages/core/test/unit/router.test.ts
+++ b/packages/core/test/unit/router.test.ts
@@ -324,9 +324,8 @@ describe("guards", () => {
     expect(snapshot.status).toBe("error");
     expect(snapshot.url.origin).not.toBe("https://evil.com");
     expect(onError).toHaveBeenCalledOnce();
-    expect((onError.mock.calls[0][0] as Error).message).toMatch(
-      /cross-origin redirect/,
-    );
+    expect(snapshot.error).toBeInstanceOf(Error);
+    expect((snapshot.error as Error).message).toMatch(/cross-origin redirect/);
   });
 
   it("sets status to 'error' and calls onError when a guard throws", async () => {

--- a/packages/core/test/unit/router.test.ts
+++ b/packages/core/test/unit/router.test.ts
@@ -307,6 +307,28 @@ describe("guards", () => {
     expect(snapshot.components).toEqual(["about"]);
   });
 
+  it("rejects a cross-origin redirect from a guard instead of navigating away", async () => {
+    const routes = [
+      { path: "/", component: "home" },
+      { path: "evil", beforeLoad: () => "https://evil.com" },
+    ] as const satisfies readonly RouteConfig<string>[];
+    const onError = vi.fn();
+    const router = new Router(routes, { onError });
+
+    router.start();
+    await flush();
+    router.navigate("/evil");
+    await flush();
+
+    const snapshot = router.getSnapshot();
+    expect(snapshot.status).toBe("error");
+    expect(snapshot.url.origin).not.toBe("https://evil.com");
+    expect(onError).toHaveBeenCalledOnce();
+    expect((onError.mock.calls[0][0] as Error).message).toMatch(
+      /cross-origin redirect/,
+    );
+  });
+
   it("sets status to 'error' and calls onError when a guard throws", async () => {
     const boom = new Error("boom");
     const routes = [


### PR DESCRIPTION
A `beforeLoad` guard returning a user-derived string (e.g. `?next=https://evil.com`)
was forwarded to `navigation.navigate()` without any origin check — an open-redirect.

**Fix:** resolve the returned string against the current URL; throw if the result is
cross-origin (catches `https://`, `//host`, and `javascript:` too). Lands in the
existing `catch` → `status:"error"` / `onError`, no new machinery.

**Also:**
- Docs updated (guards warning, FAQ rewritten, API note)
- Navbar version bumped to v1.1.1
- Changeset: `patch` for core + all adapters → releases as **1.1.1** across the suite