### PR TITLE
fix(core): harden normalizePath against ReDoS

### DIFF
--- a/.changeset/fix-redos-normalizepath.md
+++ b/.changeset/fix-redos-normalizepath.md
@@ -1,5 +1,8 @@
 ---
 "@isorouter/core": patch
+"@isorouter/react": patch
+"@isorouter/svelte": patch
+"@isorouter/vue": patch
 ---
 
 fix(core): harden normalizePath against ReDoS (CodeQL js/polynomial-redos)

--- a/.changeset/fix-redos-normalizepath.md
+++ b/.changeset/fix-redos-normalizepath.md
@@ -1,0 +1,10 @@
+---
+"@isorouter/core": patch
+---
+
+fix(core): harden normalizePath against ReDoS (CodeQL js/polynomial-redos)
+
+Replace the `/\/+$/` regex in `normalizePath` with a linear index-scan. The
+regex was quadratic on slash-heavy strings that don't reach end-of-string —
+reachable via `URL.pathname` (which does not collapse slashes) in both
+`isActive` callers.

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -31,7 +31,9 @@ function initialUrl(): URL {
 }
 
 function normalizePath(p: string): string {
-  return p.replace(/\/+$/, "") || "/";
+  let end = p.length;
+  while (end > 0 && p.charCodeAt(end - 1) === 47 /* "/" */) end--;
+  return end === 0 ? "/" : p.slice(0, end);
 }
 
 /**

--- a/packages/core/test/unit/router.test.ts
+++ b/packages/core/test/unit/router.test.ts
@@ -557,6 +557,26 @@ describe("isActive", () => {
   });
 });
 
+describe("normalizePath (trailing-slash stripping)", () => {
+  const routes = [
+    { path: "/", component: "home" },
+    { path: "foo", component: "foo" },
+  ] as const satisfies readonly RouteConfig<string>[];
+
+  it.each([
+    ["/foo/", "/foo", "strips single trailing slash"],
+    ["/foo///", "/foo", "strips multiple trailing slashes"],
+    ["/", "/", "root stays root"],
+    ["/foo", "/foo", "no trailing slash — no-op"],
+  ])("isActive treats %s same as %s (%s)", async (withSlash, withoutSlash) => {
+    const router = new Router(routes);
+    router.start();
+    await flush();
+
+    expect(router.isActive(withSlash)).toBe(router.isActive(withoutSlash));
+  });
+});
+
 describe("title", () => {
   it("applies the deepest title in the matched chain", async () => {
     const routes = [


### PR DESCRIPTION
`normalizePath` used `/\/+$/` — a polynomial regex on slash-heavy strings
that don't reach end-of-string (quadratic backtracking, CodeQL
`js/polynomial-redos` / CWE-1333). Reachable via `URL().pathname` in both
`isActive` callers, since `URL` does not collapse slashes.

**Fix:** replaced with a linear index-scan (`charCodeAt` + `slice`) — O(n),
no backtracking, identical semantics.

**Also:** regression tests for trailing-slash stripping added to
`router.test.ts`; changeset created for core and all adapters as patch
releases.

Closes security alert [#2](https://github.com/pidkhvatylin-my/isorouter/security/code-scanning/2).