### PR TITLE
fix(core): stop a sibling `*` route from shadowing root/pathless routes

### DIFF
--- a/.changeset/fix-splat-vs-root-specificity.md
+++ b/.changeset/fix-splat-vs-root-specificity.md
@@ -1,0 +1,22 @@
+---
+"@isorouter/core": patch
+"@isorouter/react": patch
+"@isorouter/svelte": patch
+"@isorouter/vue": patch
+---
+
+fix(core): let a sibling root/pathless route win over a same-level `*` splat
+
+`SEGMENT_SCORE.splat` was `1`, giving `path: "*"` a specificity of 1 — higher
+than `path: "/"`, `path: ""`, or a pathless layout, which all score 0. The
+descending-specificity sort therefore placed the splat first, so a top-level
+catch-all (`{ path: "*" }`) swallowed the home route and a subtree `*` shadowed
+its layout's index/empty route. The documented behaviour — "static > `:param` >
+`*`, ties broken by declaration order" — never held for splats against
+zero-segment siblings.
+
+Lower `splat` to `0` so it ties with zero-segment routes and the stable sort
+falls back to declaration order. Declaring an explicit `/` (or any matching
+route) before the `*` now resolves correctly; the `*` only matches when nothing
+above it does. Multi-segment splats (`a/*`) and splat-vs-splat ordering are
+unaffected.

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -124,13 +124,26 @@ defeat the compile-time `Href`/`NavTarget` typing, which is a core feature.
 
 ### How do I add a 404 / catch-all page?
 
-Declare a `*` route. At the root it catches anything unmatched; as a child it
-catches anything unmatched **within that subtree** (rendering inside the
-parent's layout):
+You have two options — pick whichever fits your app.
+
+**Global 404 — the `notFound` handler.** When nothing matches, the snapshot
+reports `status: "not-found"`. Render whatever you like via the adapter's
+`notFound` handler (Svelte snippet, React prop, Vue slot) — no layout wraps it:
+
+```svelte
+<Router {router}>
+  {#snippet notFound()}
+    <h2>404 — not found</h2>
+  {/snippet}
+</Router>
+```
+
+**Nested 404 — a `*` route.** Inside a layout's `children`, a `*` catches
+anything unmatched **within that subtree** and renders inside the parent's
+layout (status stays `"idle"`):
 
 ```ts
 [
-  { path: "/", component: Home },
   {
     path: "dashboard",
     component: DashboardLayout,
@@ -139,12 +152,12 @@ parent's layout):
       { path: "*", component: DashboardNotFound }, // 404 inside the dashboard
     ],
   },
-  { path: "*", component: NotFound }, // global 404
 ]
 ```
 
-If nothing matches and you declared no `*` route, the snapshot reports
-`status: "not-found"` and renders nothing.
+A root-level `*` route works as a global catch-all too, if you prefer it — keep
+it last so your real routes still win. Use one or the other, not both: a root
+`*` matches every URL, so the `notFound` handler never fires.
 
 ### What happens to encoded slashes (`%2F`) in a param?
 

--- a/packages/core/src/matcher.ts
+++ b/packages/core/src/matcher.ts
@@ -26,7 +26,7 @@ const SPLAT = "*";
 const SEGMENT_SCORE = {
   static: 10,
   param: 4,
-  splat: 1,
+  splat: 0,
 } as const;
 
 /**

--- a/packages/core/test/unit/matcher/basic.test.ts
+++ b/packages/core/test/unit/matcher/basic.test.ts
@@ -99,7 +99,9 @@ describe("matchRoutes", () => {
         { path: "*", component: "catchall" },
       ];
       expect(matchRoutes(routes, "/")?.chain[0]?.component).toBe("home");
-      expect(matchRoutes(routes, "/missing")?.chain[0]?.component).toBe("catchall");
+      expect(matchRoutes(routes, "/missing")?.chain[0]?.component).toBe(
+        "catchall",
+      );
     });
 
     it("catches unmatched paths inside a nested route subtree", () => {
@@ -113,8 +115,12 @@ describe("matchRoutes", () => {
           ],
         },
       ];
-      expect(matchRoutes(routes, "/dashboard/settings")?.chain.at(-1)?.component).toBe("settings");
-      expect(matchRoutes(routes, "/dashboard/unknown")?.chain.at(-1)?.component).toBe("not-found");
+      expect(
+        matchRoutes(routes, "/dashboard/settings")?.chain.at(-1)?.component,
+      ).toBe("settings");
+      expect(
+        matchRoutes(routes, "/dashboard/unknown")?.chain.at(-1)?.component,
+      ).toBe("not-found");
     });
   });
 

--- a/packages/core/test/unit/matcher/basic.test.ts
+++ b/packages/core/test/unit/matcher/basic.test.ts
@@ -92,6 +92,30 @@ describe("matchRoutes", () => {
       ];
       expect(matchRoutes(routes, "/")?.params).toEqual({ "*": "" });
     });
+
+    it("does not match the root '/' route when a more specific path: '/' route is declared first", () => {
+      const routes: RouteConfig<string>[] = [
+        { path: "/", component: "home" },
+        { path: "*", component: "catchall" },
+      ];
+      expect(matchRoutes(routes, "/")?.chain[0]?.component).toBe("home");
+      expect(matchRoutes(routes, "/missing")?.chain[0]?.component).toBe("catchall");
+    });
+
+    it("catches unmatched paths inside a nested route subtree", () => {
+      const routes: RouteConfig<string>[] = [
+        {
+          path: "dashboard",
+          component: "layout",
+          children: [
+            { path: "settings", component: "settings" },
+            { path: "*", component: "not-found" },
+          ],
+        },
+      ];
+      expect(matchRoutes(routes, "/dashboard/settings")?.chain.at(-1)?.component).toBe("settings");
+      expect(matchRoutes(routes, "/dashboard/unknown")?.chain.at(-1)?.component).toBe("not-found");
+    });
   });
 
   describe("index routes", () => {


### PR DESCRIPTION
## Summary

A root-level `{ path: "*" }` catch-all swallowed the home route, so the
documented 404 pattern silently broke. `SEGMENT_SCORE.splat` was `1`, giving
`path: "*"` a specificity of **1** — higher than `path: "/"`, `path: ""`, and
pathless layouts, which all score **0**. The descending-specificity sort placed
the splat first, so it matched before any zero-segment sibling, regardless of
declaration order.

This contradicted the matcher's own documented contract:
> static > `:param` > `*`, ties broken by declaration order.

That guarantee never held for a `*` against a zero-segment sibling.

## Fix

Lower `SEGMENT_SCORE.splat` from `1` to `0` so a `*` **ties** with zero-segment
routes and the stable sort falls back to declaration order. An explicit `/` (or
any matching route) declared before the `*` now wins; the `*` only matches when
nothing above it does.

Unaffected: multi-segment splats (`a/*` still scores 10), splat-vs-splat
ordering, and static/param ranking.

## API / compatibility

- **No public API change** — `SEGMENT_SCORE` is module-private; only
  `matchRoutes` is exported. No type or signature changes.
- **Backward compatible** — the only behavioral change is that a `*` no longer
  outranks a same-level zero-segment route; declaration order now decides. The
  previous behavior (a `*` silently beating an explicit root route) was never a
  documented guarantee.

## Tests

- All 148 core tests pass.
- Added regressions: root `/` vs root `*`, and a `*` catch-all inside a nested
  subtree.

## Docs

Reworked the "404 / catch-all" FAQ to show the `notFound` handler for the global
404 and a `*` route for nested subtrees, with a root-level `*` mentioned as an
optional alternative (use one or the other).

## Changeset

`patch` across all four linked packages (`@isorouter/core` + adapters).