### PR TITLE
feat(core): add `from` to GuardContext

### DIFF
--- a/.changeset/guard-from.md
+++ b/.changeset/guard-from.md
@@ -1,0 +1,30 @@
+---
+"@isorouter/core": minor
+"@isorouter/react": minor
+"@isorouter/svelte": minor
+"@isorouter/vue": minor
+---
+
+Add `from` to the guard context: `beforeLoad` guards now receive `ctx.from`,
+the location the navigation is leaving.
+
+- `GuardContext` gains `from: GuardLocation | null`. It carries the previous
+  **committed** location as `{ url, params }`, or `null` on the first
+  navigation after a page load. A navigation that a guard blocks or redirects,
+  or one superseded mid-flight, never commits — so it never becomes anyone's
+  `from`. A `not-found` or `error` landing _does_ count as committed, since the
+  URL changed and the user is looking at that address.
+- A new `GuardLocation` type (`{ url: URL; params: Record<string, string> }`)
+  is exported from the core and re-exported by each adapter. It is deliberately
+  narrower than `RouterSnapshot` — a guard needs the previous location, not the
+  previous render.
+
+`from` is purely additive (guards receive an extra field); existing guards need
+no changes. Use it for referrer analytics, origin-aware redirects, or reading
+the previous route's params:
+
+```ts
+beforeLoad: ({ from }) => {
+  if (from?.url.pathname.startsWith("/app")) return "/app/dashboard";
+};
+```

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -90,12 +90,17 @@ for you on mount/unmount.
 
 ```ts twoslash
 type Awaitable<T> = T | Promise<T>;
+interface GuardLocation {
+  url: URL;
+  params: Record<string, string>;
+}
 interface GuardContext {
   params: Record<string, string>;
   url: URL;
   pathname: string;
   signal: AbortSignal;
   navigationType: "reload" | "push" | "replace" | "traverse";
+  from: GuardLocation | null;
 }
 type BeforeLoad = (ctx: GuardContext) => Awaitable<void | boolean | string>;
 interface LazyComponent<C> {
@@ -170,13 +175,20 @@ implement the `Register` / `RegisteredRouter` module-augmentation pattern. See
 ```ts twoslash
 type Awaitable<T> = T | Promise<T>;
 // ---cut---
+interface GuardLocation {
+  url: URL;
+  params: Record<string, string>;
+}
+
 interface GuardContext {
   params: Record<string, string>;
   url: URL;
   pathname: string;
+  navigationType: "reload" | "push" | "replace" | "traverse";
+  /** The last committed location, or `null` on the first navigation. */
+  from: GuardLocation | null;
   /** Aborts when this navigation is superseded by a newer one. */
   signal: AbortSignal;
-  navigationType: "reload" | "push" | "replace" | "traverse";
 }
 
 type BeforeLoad = (ctx: GuardContext) => Awaitable<void | boolean | string>;
@@ -184,8 +196,9 @@ type BeforeLoad = (ctx: GuardContext) => Awaitable<void | boolean | string>;
 
 Return nothing/`true` to allow, `false` to block (current URL restored), or a
 same-origin `string` to redirect (`replace`); a cross-origin string throws
-(`status: "error"`) rather than navigating. See
-[Navigation guards](../guide/guards).
+(`status: "error"`) rather than navigating. `from` is the previous **committed**
+location — a blocked, redirected or superseded navigation never becomes anyone's
+`from`. See [Navigation guards](../guide/guards).
 
 ### `RouteMetadata` & `MetadataContext`
 
@@ -212,8 +225,8 @@ declare module "@isorouter/core" {
 }
 ```
 
-`MetadataContext` is a narrower `GuardContext`: no `signal` or
-`navigationType`, since a metadata function isn't part of the guard pipeline.
+`MetadataContext` is a narrower `GuardContext`: no `signal`, `navigationType`,
+or `from`, since a metadata function isn't part of the guard pipeline.
 A function form must be **synchronous and pure** — it's resolved during
 commit, and it is **not called** for a navigation a guard blocks or redirects.
 See [Route metadata](../guide/routing#route-metadata).
@@ -263,8 +276,8 @@ interface RouterOptions {
 
 `createCoreRouter`, `Router`, `matchRoutes`, `lazy`, `isLazy`, and the types
 `AnyRouter`, `Unsubscribe`, `LazyComponent`, `Awaitable`, `BeforeLoad`,
-`ExtractParams`, `GuardContext`, `Href`, `MetadataContext`, `NavTarget`,
-`NavigationKind`, `ResolveRegister`, `RouteConfig`, `RouteMatch`,
+`ExtractParams`, `GuardContext`, `GuardLocation`, `Href`, `MetadataContext`,
+`NavTarget`, `NavigationKind`, `ResolveRegister`, `RouteConfig`, `RouteMatch`,
 `RouteMetadata`, `RouteTemplate`, `RouterOptions`, `RouterSnapshot`.
 
 ## Other targets (TypeScript)

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -27,8 +27,8 @@ npm install @isorouter/react
 
 `RouterProps`, `LinkProps`, `AnyReactRouter`, `ReactComponentType`, `Register`,
 `RegisteredRouter`, plus the core re-exports `BeforeLoad`, `GuardContext`,
-`Href`, `MetadataContext`, `NavTarget`, `RouteConfig`, `RouteMetadata`,
-`RouterOptions`, `RouterSnapshot`.
+`GuardLocation`, `Href`, `MetadataContext`, `NavTarget`, `RouteConfig`,
+`RouteMetadata`, `RouterOptions`, `RouterSnapshot`.
 
 Augment `Register` to narrow `useRouter()` and `useNavigate()` to the concrete
 router type — see [Type-safe navigation](../guide/type-safe-navigation#module-augmentation).

--- a/docs/api/svelte.md
+++ b/docs/api/svelte.md
@@ -22,8 +22,9 @@ npm install @isorouter/svelte
 ## Types
 
 `AnySvelteRouter`, `SvelteComponentType`, `Register`, `RegisteredRouter`, plus
-the core re-exports `BeforeLoad`, `GuardContext`, `Href`, `MetadataContext`,
-`NavTarget`, `RouteConfig`, `RouteMetadata`, `RouterOptions`, `RouterSnapshot`.
+the core re-exports `BeforeLoad`, `GuardContext`, `GuardLocation`, `Href`,
+`MetadataContext`, `NavTarget`, `RouteConfig`, `RouteMetadata`, `RouterOptions`,
+`RouterSnapshot`.
 
 Augment `Register` to narrow `getRouter()` to the concrete router type — see
 [Type-safe navigation](../guide/type-safe-navigation#module-augmentation).

--- a/docs/api/vue.md
+++ b/docs/api/vue.md
@@ -26,8 +26,9 @@ npm install @isorouter/vue
 ## Types
 
 `AnyVueRouter`, `VueComponentType`, `Register`, `RegisteredRouter`, plus the
-core re-exports `BeforeLoad`, `GuardContext`, `Href`, `MetadataContext`,
-`NavTarget`, `RouteConfig`, `RouteMetadata`, `RouterOptions`, `RouterSnapshot`.
+core re-exports `BeforeLoad`, `GuardContext`, `GuardLocation`, `Href`,
+`MetadataContext`, `NavTarget`, `RouteConfig`, `RouteMetadata`, `RouterOptions`,
+`RouterSnapshot`.
 
 Augment `Register` to narrow `useRouter()` and `useNavigate()` to the concrete
 router type — see [Type-safe navigation](../guide/type-safe-navigation#module-augmentation).

--- a/docs/guide/guards.md
+++ b/docs/guide/guards.md
@@ -9,13 +9,20 @@ navigation never flashes the target UI.
 ```ts twoslash
 type Awaitable<T> = T | Promise<T>;
 
+interface GuardLocation {
+  url: URL;
+  params: Record<string, string>;
+}
+
 interface GuardContext {
   params: Record<string, string>;
   url: URL;
   pathname: string;
+  navigationType: "reload" | "push" | "replace" | "traverse";
+  /** Where the navigation came from, or `null` on the first load. */
+  from: GuardLocation | null;
   /** Aborts when this navigation is superseded by a newer one. */
   signal: AbortSignal;
-  navigationType: "reload" | "push" | "replace" | "traverse";
 }
 
 type BeforeLoad = (ctx: GuardContext) => Awaitable<void | boolean | string>;
@@ -53,6 +60,44 @@ the router throws instead of navigating and the snapshot moves to
 `status: "error"` — this closes the open-redirect class where a user-derived
 `?next=` could send visitors to an external site. Same-origin and relative paths
 are unaffected.
+:::
+
+## Where the navigation came from: `from`
+
+Every guard sees `ctx.from` — the location the user is **leaving**, as
+`{ url, params }`, or `null` on the very first navigation after a page load.
+
+```ts twoslash
+import { createCoreRouter } from "@isorouter/core";
+
+declare const Dashboard: unknown;
+declare function track(event: string, data: unknown): void;
+// ---cut---
+const router = createCoreRouter([
+  {
+    path: "/dashboard",
+    component: Dashboard,
+    beforeLoad: ({ url, from }) => {
+      // Referrer analytics — `from` is null on a cold load, so guard with `?.`
+      track("nav", { to: url.pathname, from: from?.url.pathname ?? "(direct)" });
+
+      // Origin-aware redirect: skip the intro when arriving from inside the app.
+      if (from?.url.pathname.startsWith("/app")) return "/app/dashboard";
+    },
+  },
+] as const);
+```
+
+`from` is the last location the router **committed** — never a navigation that
+was blocked, redirected, or superseded mid-flight, so the next guard always sees
+the location the user actually saw. A `not-found` or `error` landing *does*
+count: the URL changed and the user is looking at that address.
+
+::: tip Where from, not a leave-guard
+`from` answers "where did we come from", not "may we leave". You can't cancel
+the exit from here — by the time a guard runs, that navigation has already
+started. It's also not a history direction: back vs. forward can't be inferred
+from two URLs (use `navigationType` for `"traverse"`).
 :::
 
 ## Async guards & the abort signal

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -22,8 +22,8 @@ a general `metadata` bag that the router carries but never interprets — see
 ```
 
 The `metadata` function receives `MetadataContext` — `params`, `url`,
-`pathname` — a narrower type than `GuardContext` (no `signal` or
-`navigationType`, since it isn't part of the guard pipeline).
+`pathname` — a narrower type than `GuardContext` (no `signal`, `navigationType`,
+or `from`, since it isn't part of the guard pipeline).
 
 ## The one line you must add: `onCommit`
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export type {
   BeforeLoad,
   ExtractParams,
   GuardContext,
+  GuardLocation,
   Href,
   MetadataContext,
   NavTarget,

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -90,12 +90,6 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
   #commitAbort: AbortController | null = null;
   #started = false;
   #listener = (e: NavigateEvent) => this.#onNavigate(e);
-  /**
-   * Last location the router settled on — the `from` of the next navigation.
-   * Distinct from `#snapshot` because it must survive only *terminal* emits:
-   * a blocked, redirected or superseded navigation returns before reaching one,
-   * so it never becomes anyone's `from`. `null` until the first commit.
-   */
   #committed: GuardLocation | null = null;
 
   constructor(routes: T, options: RouterOptions = {}) {
@@ -271,8 +265,6 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
         pathname: url.pathname,
         signal: abortController.signal,
         navigationType,
-        // Read before this navigation settles, so guards see the location the
-        // user is leaving — never the one they're heading to.
         from: this.#committed,
       };
 

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -12,6 +12,7 @@ import { matchRoutes } from "./matcher";
 
 import type {
   GuardContext,
+  GuardLocation,
   MetadataContext,
   NavTarget,
   NavigationKind,
@@ -89,6 +90,13 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
   #commitAbort: AbortController | null = null;
   #started = false;
   #listener = (e: NavigateEvent) => this.#onNavigate(e);
+  /**
+   * Last location the router settled on — the `from` of the next navigation.
+   * Distinct from `#snapshot` because it must survive only *terminal* emits:
+   * a blocked, redirected or superseded navigation returns before reaching one,
+   * so it never becomes anyone's `from`. `null` until the first commit.
+   */
+  #committed: GuardLocation | null = null;
 
   constructor(routes: T, options: RouterOptions = {}) {
     this.routes = routes;
@@ -123,13 +131,22 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
   }
 
   /**
-   * Publishes a *terminal* snapshot — one the router settles on — and notifies
-   * `onCommit`. Every exit from `#commit` that lands on a URL goes through
-   * here, including not-found and error: the app owns `document.title` now, so
-   * a 404 landing has to reach it too. Blocked, redirected and superseded
-   * navigations return earlier and never settle.
+   * Publishes a *terminal* snapshot — one the router settles on — records it as
+   * the next navigation's `from`, and notifies `onCommit`. Every exit from
+   * `#commit` that lands on a URL goes through here, including not-found and
+   * error: the app owns `document.title` now, so a 404 landing has to reach it
+   * too, and the user is looking at that address. Blocked, redirected and
+   * superseded navigations return earlier and never settle — so the `from`
+   * invariant holds structurally rather than by updating a field at each call
+   * site.
    */
-  #settle(patch: Partial<RouterSnapshot<C>>): void {
+  #settle(
+    patch: Partial<RouterSnapshot<C>> & {
+      url: URL;
+      params: Record<string, string>;
+    },
+  ): void {
+    this.#committed = { url: patch.url, params: patch.params };
     this.#emit(patch);
     this.#options.onCommit?.(this.#snapshot);
   }
@@ -254,6 +271,9 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
         pathname: url.pathname,
         signal: abortController.signal,
         navigationType,
+        // Read before this navigation settles, so guards see the location the
+        // user is leaving — never the one they're heading to.
+        from: this.#committed,
       };
 
       for (const route of matched.chain) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,10 +16,28 @@ export interface MetadataContext {
   pathname: string;
 }
 
+/**
+ * Where a navigation came from. Deliberately narrower than `RouterSnapshot` —
+ * a guard needs the previous location, not the previous render (components and
+ * status would tilt this toward carrying a history stack in the guard context).
+ */
+export interface GuardLocation {
+  url: URL;
+  params: Record<string, string>;
+}
+
 export interface GuardContext extends MetadataContext {
   /** Aborts when this navigation is superseded by a newer one. */
   signal: AbortSignal;
   navigationType: NavigationKind;
+  /**
+   * The last **committed** location, or `null` on the first navigation after a
+   * page load. A blocked, redirected or superseded navigation never becomes
+   * anyone's `from`. This is "where from", not a leave-guard (the moment has
+   * passed — you cannot cancel the exit) and not a history direction
+   * (back/forward can't be derived from two URLs).
+   */
+  from: GuardLocation | null;
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,17 +27,9 @@ export interface GuardLocation {
 }
 
 export interface GuardContext extends MetadataContext {
-  /** Aborts when this navigation is superseded by a newer one. */
-  signal: AbortSignal;
   navigationType: NavigationKind;
-  /**
-   * The last **committed** location, or `null` on the first navigation after a
-   * page load. A blocked, redirected or superseded navigation never becomes
-   * anyone's `from`. This is "where from", not a leave-guard (the moment has
-   * passed — you cannot cancel the exit) and not a history direction
-   * (back/forward can't be derived from two URLs).
-   */
   from: GuardLocation | null;
+  signal: AbortSignal;
 }
 
 /**

--- a/packages/core/test/unit/router.test.ts
+++ b/packages/core/test/unit/router.test.ts
@@ -12,6 +12,7 @@ import { FakeNavigation } from "@isorouter/test-utils";
 import { lazy } from "../../src/lazy";
 import { createCoreRouter, Router } from "../../src/router";
 import type {
+  GuardContext,
   MetadataContext,
   RouteConfig,
   RouterSnapshot,
@@ -880,5 +881,137 @@ describe("back / forward", () => {
     await flush();
 
     expect(router.getSnapshot()).toBe(before);
+  });
+});
+
+describe("guard context: from", () => {
+  /** Captures the `from` seen by the guard on the route it is attached to. */
+  function spyFrom() {
+    const seen: (GuardContext["from"] | undefined)[] = [];
+    return {
+      seen,
+      guard: (ctx: GuardContext) => {
+        seen.push(ctx.from);
+      },
+    };
+  }
+
+  it("is null on the first navigation after a page load", async () => {
+    const spy = spyFrom();
+    const routes = [
+      { path: "/", component: "home", beforeLoad: spy.guard },
+    ] as const satisfies readonly RouteConfig<string>[];
+
+    new Router(routes).start();
+    await flush();
+
+    expect(spy.seen).toEqual([null]);
+  });
+
+  it("carries the previous committed url and params", async () => {
+    const spy = spyFrom();
+    const routes = [
+      { path: "/", component: "home" },
+      { path: "users/:id", component: "user" },
+      { path: "about", component: "about", beforeLoad: spy.guard },
+    ] as const satisfies readonly RouteConfig<string>[];
+    const router = new Router(routes);
+
+    router.start();
+    await flush();
+    router.navigate("/users/42");
+    await flush();
+    router.navigate("/about");
+    await flush();
+
+    expect(spy.seen).toHaveLength(1);
+    expect(spy.seen[0]?.url.pathname).toBe("/users/42");
+    expect(spy.seen[0]?.params).toEqual({ id: "42" });
+  });
+
+  it("does not become the next navigation's from when a guard blocks", async () => {
+    const spy = spyFrom();
+    const routes = [
+      { path: "/", component: "home" },
+      { path: "blocked", component: "blocked", beforeLoad: () => false },
+      { path: "about", component: "about", beforeLoad: spy.guard },
+    ] as const satisfies readonly RouteConfig<string>[];
+    const router = new Router(routes);
+
+    router.start();
+    await flush();
+    router.navigate("/blocked");
+    await flush();
+    router.navigate("/about");
+    await flush();
+
+    // The blocked attempt never committed — from is still the home page.
+    expect(spy.seen[0]?.url.pathname).toBe("/");
+  });
+
+  it("skips the redirecting route and reports the redirect target as from", async () => {
+    const spy = spyFrom();
+    const routes = [
+      { path: "/", component: "home" },
+      { path: "old", beforeLoad: () => "/new" },
+      { path: "new", component: "new" },
+      { path: "about", component: "about", beforeLoad: spy.guard },
+    ] as const satisfies readonly RouteConfig<string>[];
+    const router = new Router(routes);
+
+    router.start();
+    await flush();
+    router.navigate("/old");
+    await flush();
+    router.navigate("/about");
+    await flush();
+
+    // "/old" never committed; "/new" did.
+    expect(spy.seen[0]?.url.pathname).toBe("/new");
+  });
+
+  it("treats a not-found landing as a committed location", async () => {
+    const spy = spyFrom();
+    const routes = [
+      { path: "/", component: "home" },
+      { path: "about", component: "about", beforeLoad: spy.guard },
+    ] as const satisfies readonly RouteConfig<string>[];
+    const router = new Router(routes);
+
+    router.start();
+    await flush();
+    router.navigate("/nope" as never);
+    await flush();
+    router.navigate("/about");
+    await flush();
+
+    expect(router.getSnapshot().status).toBe("idle");
+    expect(spy.seen[0]?.url.pathname).toBe("/nope");
+    expect(spy.seen[0]?.params).toEqual({});
+  });
+
+  it("is observed by every guard in the chain, root → leaf", async () => {
+    const parent = spyFrom();
+    const child = spyFrom();
+    const routes = [
+      { path: "/", component: "home" },
+      {
+        path: "dashboard",
+        component: "layout",
+        beforeLoad: parent.guard,
+        children: [
+          { path: "settings", component: "settings", beforeLoad: child.guard },
+        ],
+      },
+    ] as const satisfies readonly RouteConfig<string>[];
+    const router = new Router(routes);
+
+    router.start();
+    await flush();
+    router.navigate("/dashboard/settings");
+    await flush();
+
+    expect(parent.seen[0]?.url.pathname).toBe("/");
+    expect(child.seen[0]?.url.pathname).toBe("/");
   });
 });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,7 @@ export { lazy } from "@isorouter/core";
 export type {
   BeforeLoad,
   GuardContext,
+  GuardLocation,
   Href,
   MetadataContext,
   NavTarget,

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -2,6 +2,7 @@ export { lazy } from "@isorouter/core";
 export type {
   BeforeLoad,
   GuardContext,
+  GuardLocation,
   Href,
   MetadataContext,
   NavTarget,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -2,6 +2,7 @@ export { lazy } from "@isorouter/core";
 export type {
   BeforeLoad,
   GuardContext,
+  GuardLocation,
   Href,
   MetadataContext,
   NavTarget,


### PR DESCRIPTION
## What

`beforeLoad` guards can now see where a navigation came from. `GuardContext`
gains a `from` field carrying the previous **committed** location:

```ts
interface GuardLocation {
  url: URL;
  params: Record<string, string>;
}

interface GuardContext {
  // …existing fields
  from: GuardLocation | null; // null on the first navigation after page load
}
```

## Why

Guards had no way to answer "where did the user come from?" — needed for
referrer analytics, origin-aware redirects, and reading the previous route's
params. from fills that gap without turning the guard context into a history
stack.

```ts
beforeLoad: ({ url, from }) => {
  track("nav", { to: url.pathname, from: from?.url.pathname ?? "(direct)" });
  if (from?.url.pathname.startsWith("/app")) return "/app/dashboard";
};
```

## Design notes

- Narrow by intent. GuardLocation is { url, params } only — no
components/status (that would tilt it toward a history stack) and no
duplicated pathname (from.url.pathname is unambiguous).
- Correctness is structural, not by convention. from advances only when
the router settles on a location. Every terminal exit from #commit already
goes through the private #settle() (introduced by the metadata work in #34),
so blocked / redirected / superseded navigations return early and never become
anyone's from.
- not-found / error count as committed — the URL changed and the user is
looking at that address.
- from lives on GuardContext, not MetadataContext — metadata functions
aren't part of the guard pipeline and don't see it.
- Purely additive: existing guards need no changes.

## Changes

- @isorouter/core: from on GuardContext, new exported GuardLocation type,
#committed recorded in #settle.
- @isorouter/{react,svelte,vue}: re-export GuardLocation alongside
GuardContext.
- Docs: guards guide (new "Where the navigation came from" section), core API
reference, adapter re-export lists, migration note.
- Changeset: minor across all four packages.

## Testing

- 6 new unit tests covering: null on cold load, previous url/params carried,
blocked/redirected navs never become from, not-found counts as committed,
and every guard in the chain (root → leaf) sees it.
- npm run check green across all workspaces; npm run docs:build passes
(twoslash type-checks every code block); core tests 164/164.
