### PR TITLE
feat(core): support object redirect targets from beforeLoad guards

### DIFF
--- a/.changeset/guard-redirect-object.md
+++ b/.changeset/guard-redirect-object.md
@@ -1,0 +1,5 @@
+---
+"@isorouter/core": minor
+---
+
+`beforeLoad` guards can now return a `RedirectTarget` object (`{ to, replace?, state? }`) to control push-vs-replace and attach history state on redirect. Returning a plain string still redirects with `replace: true`. Cross-origin redirect targets remain rejected.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export type {
   MetadataContext,
   NavTarget,
   NavigationKind,
+  RedirectTarget,
   ResolveRegister,
   RouteConfig,
   RouteMatch,

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -16,6 +16,7 @@ import type {
   MetadataContext,
   NavTarget,
   NavigationKind,
+  RedirectTarget,
   RouteConfig,
   RouteMetadata,
   RouterOptions,
@@ -58,6 +59,22 @@ function mergeMetadata<C>(
   }
 
   return merged ?? EMPTY_METADATA;
+}
+
+type GuardOutcome =
+  | { kind: "allow" }
+  | { kind: "block" }
+  | { kind: "redirect"; target: RedirectTarget };
+
+/** Collapses every `beforeLoad` return shape into one so the commit loop is uniform. */
+function normalizeGuardResult(
+  r: void | boolean | string | RedirectTarget,
+): GuardOutcome {
+  if (r == null || r === true) return { kind: "allow" };
+  if (r === false) return { kind: "block" };
+  if (typeof r === "string")
+    return { kind: "redirect", target: { to: r, replace: true } };
+  return { kind: "redirect", target: { replace: true, ...r } }; // default replace; object overrides
 }
 
 /**
@@ -271,29 +288,31 @@ export class Router<const T extends readonly RouteConfig<C>[], C = unknown> {
       for (const route of matched.chain) {
         if (!route.beforeLoad) continue;
 
-        const result = await route.beforeLoad(ctx);
+        const outcome = normalizeGuardResult(await route.beforeLoad(ctx));
 
         if (abortController.signal.aborted) return;
 
-        if (result === false) {
+        if (outcome.kind === "block") {
           this.#navigateRaw(this.#snapshot.url.href, true); // restore
           return;
         }
 
-        if (typeof result === "string") {
-          // Guard strings may be user-derived (e.g. a ?next= param); reject
+        if (outcome.kind === "redirect") {
+          const { target } = outcome;
+
+          // Guard targets may be user-derived (e.g. a ?next= param); reject
           // cross-origin targets so a guard can't be turned into an open
           // redirect. Resolving against the current URL also catches
           // protocol-relative (//evil.com) and opaque (javascript:) targets,
           // whose origin won't match. Same-origin / relative paths pass through.
-          const target = new URL(result, this.#snapshot.url.href);
-          if (target.origin !== this.#snapshot.url.origin)
+          const url = new URL(target.to, this.#snapshot.url.href);
+          if (url.origin !== this.#snapshot.url.origin)
             throw new Error(
               `[isorouter] beforeLoad returned a cross-origin redirect ` +
-                `("${result}"); only same-origin paths are allowed`,
+                `("${target.to}"); only same-origin paths are allowed`,
             );
 
-          this.#navigateRaw(result, true); // redirect
+          this.#navigateRaw(target.to, target.replace ?? true, target.state); // redirect
           return;
         }
       }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -54,15 +54,26 @@ export interface RouteMetadata extends Record<
   unknown
 > {}
 
+/** Richer redirect a guard can return in place of a plain string. */
+export interface RedirectTarget {
+  /** Same-origin path to redirect to. Cross-origin targets are rejected. */
+  to: string;
+  /** `true` (default) replaces the current entry; `false` pushes a new one. */
+  replace?: boolean;
+  /** History state to attach to the redirect navigation. */
+  state?: unknown;
+}
+
 /**
  * Navigation guard. Runs root → leaf before the matched components commit.
- *  - `undefined` / `true` → allow
- *  - `false`              → block (current URL is restored)
- *  - `string`             → redirect (replace) to that path
+ *  - `undefined` / `true`  → allow
+ *  - `false`               → block (current URL is restored)
+ *  - `string`              → redirect (replace) to that path
+ *  - `RedirectTarget`      → redirect with control over push/replace and state
  */
 export type BeforeLoad = (
   ctx: GuardContext,
-) => Awaitable<void | boolean | string>;
+) => Awaitable<void | boolean | string | RedirectTarget>;
 
 export interface RouteConfig<C = unknown> {
   path?: string;

--- a/packages/core/test/unit/router.test.ts
+++ b/packages/core/test/unit/router.test.ts
@@ -299,6 +299,7 @@ describe("guards", () => {
       { path: "about", component: "about" },
     ] as const satisfies readonly RouteConfig<string>[];
     const router = new Router(routes);
+    const navigateSpy = vi.spyOn(nav, "navigate");
 
     router.start();
     await flush();
@@ -309,12 +310,107 @@ describe("guards", () => {
     expect(snapshot.url.pathname).toBe("/about");
     expect(snapshot.status).toBe("idle");
     expect(snapshot.components).toEqual(["about"]);
+
+    // A plain string still redirects with `replace: true`.
+    const redirectCall = navigateSpy.mock.calls.find(([to]) => to === "/about");
+    expect(redirectCall?.[1]).toMatchObject({ history: "replace" });
   });
 
   it("rejects a cross-origin redirect from a guard instead of navigating away", async () => {
     const routes = [
       { path: "/", component: "home" },
       { path: "evil", beforeLoad: () => "https://evil.com" },
+    ] as const satisfies readonly RouteConfig<string>[];
+    const onError = vi.fn();
+    const router = new Router(routes, { onError });
+
+    router.start();
+    await flush();
+    router.navigate("/evil");
+    await flush();
+
+    const snapshot = router.getSnapshot();
+    expect(snapshot.status).toBe("error");
+    expect(snapshot.url.origin).not.toBe("https://evil.com");
+    expect(onError).toHaveBeenCalledOnce();
+    expect(snapshot.error).toBeInstanceOf(Error);
+    expect((snapshot.error as Error).message).toMatch(/cross-origin redirect/);
+  });
+
+  it("redirects with a push when beforeLoad returns a RedirectTarget with replace: false", async () => {
+    const routes = [
+      { path: "/", component: "home" },
+      {
+        path: "redirect",
+        beforeLoad: () => ({ to: "/about", replace: false }),
+      },
+      { path: "about", component: "about" },
+    ] as const satisfies readonly RouteConfig<string>[];
+    const router = new Router(routes);
+    const navigateSpy = vi.spyOn(nav, "navigate");
+
+    router.start();
+    await flush();
+    router.navigate("/redirect");
+    await flush();
+
+    const snapshot = router.getSnapshot();
+    expect(snapshot.url.pathname).toBe("/about");
+    expect(snapshot.status).toBe("idle");
+
+    const redirectCall = navigateSpy.mock.calls.find(([to]) => to === "/about");
+    expect(redirectCall?.[1]).toMatchObject({ history: "push" });
+  });
+
+  it("redirects (replace) when beforeLoad returns a RedirectTarget without an explicit replace", async () => {
+    const routes = [
+      { path: "/", component: "home" },
+      { path: "redirect", beforeLoad: () => ({ to: "/about" }) },
+      { path: "about", component: "about" },
+    ] as const satisfies readonly RouteConfig<string>[];
+    const router = new Router(routes);
+    const navigateSpy = vi.spyOn(nav, "navigate");
+
+    router.start();
+    await flush();
+    router.navigate("/redirect");
+    await flush();
+
+    expect(router.getSnapshot().url.pathname).toBe("/about");
+
+    const redirectCall = navigateSpy.mock.calls.find(([to]) => to === "/about");
+    expect(redirectCall?.[1]).toMatchObject({ history: "replace" });
+  });
+
+  it("passes state through when beforeLoad returns a RedirectTarget", async () => {
+    const routes = [
+      { path: "/", component: "home" },
+      {
+        path: "redirect",
+        beforeLoad: () => ({ to: "/about", state: { from: "guard" } }),
+      },
+      { path: "about", component: "about" },
+    ] as const satisfies readonly RouteConfig<string>[];
+    const router = new Router(routes);
+    const navigateSpy = vi.spyOn(nav, "navigate");
+
+    router.start();
+    await flush();
+    router.navigate("/redirect");
+    await flush();
+
+    expect(router.getSnapshot().url.pathname).toBe("/about");
+
+    const redirectCall = navigateSpy.mock.calls.find(([to]) => to === "/about");
+    expect(redirectCall?.[1]).toMatchObject({
+      state: { from: "guard" },
+    });
+  });
+
+  it("rejects a cross-origin RedirectTarget from a guard instead of navigating away", async () => {
+    const routes = [
+      { path: "/", component: "home" },
+      { path: "evil", beforeLoad: () => ({ to: "https://evil.com" }) },
     ] as const satisfies readonly RouteConfig<string>[];
     const onError = vi.fn();
     const router = new Router(routes, { onError });


### PR DESCRIPTION
## Summary

`beforeLoad` guards can now return a `RedirectTarget` object to control push-vs-replace and attach history state on redirect. Returning a plain string still redirects with `replace: true`.

## Motivation

Guard redirects were string-only and always `replace: true`. Real flows need more: pushing a redirect so Back works (e.g. login interstitials), and passing `state` to the target.

## Changes

- **New `RedirectTarget`** (`{ to, replace?, state? }`), exported from the barrel; `BeforeLoad`'s return union widened to `void | boolean | string | RedirectTarget`.
- **`normalizeGuardResult`** collapses every guard return shape (`undefined`/`true` → allow, `false` → block, `string`/object → redirect) into one, keeping the commit loop uniform.
- The existing **same-origin guard is preserved** — cross-origin, protocol-relative (`//evil.com`), and opaque (`javascript:`) targets are still rejected, so a guard can't be turned into an open redirect.
- The abort check stays immediately after `await beforeLoad(ctx)`, so a redirect can't slip past a superseded navigation.

## API

```ts
beforeLoad: ({ from }) =>
  authed ? true : { to: "/login", replace: false, state: { next: from?.url.pathname } };

beforeLoad: () => "/login"; // unchanged — string still redirects with replace: true
```

## Testing

4 new tests + 1 enhanced (test/unit/router.test.ts): object redirect push (replace: false), state passthrough, cross-origin object rejection, and the string form asserted as a replace. Full core suite: 168/168 green; tsc, publint, eslint, prettier clean.

## Compatibility

Additive. String-returning guards are unchanged.