### PR TITLE
ci: pin changesets/action back to v1 for CLI v2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         run: npm ci
 
       - name: Create Release Pull Request or publish to npm
-        uses: changesets/action@v2
+        uses: changesets/action@v1
         with:
           version: npm run version
           publish: npm run release


### PR DESCRIPTION
changesets/action@v2 requires Changesets CLI v3 and renamed the version/publish inputs to version-script/publish-script, breaking the release job. Revert the dependabot bump (#38) until we move to CLI v3.